### PR TITLE
Fix typo in package name while fetching resource filename: s/pyopencl…

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -194,7 +194,7 @@ def _find_pyopencl_include_path():
     try:
         # Try to find the resource with pkg_resources (the recommended
         # setuptools approach)
-        return resource_filename(Requirement.parse("pyopencl2"), "pyopencl/cl")
+        return resource_filename(Requirement.parse("pyopencl"), "pyopencl/cl")
     except DistributionNotFound:
         # If pkg_resources can't find it (e.g. if the module is part of a
         # frozen application), try to find the include path in the same


### PR DESCRIPTION
Hi,

I believe the fix below is a typo in the code where a resource references pyopencl2. Unfortunately, this prevents PyInstaller from bundling the library properly when e.g. the following hook is being used:

```
# We need metadata for pyopencl
from PyInstaller.utils.hooks import copy_metadata
datas = copy_metadata('pyopencl')
```