### PR TITLE
Fix ppc64le compilation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def get_config_schema():
             IncludeDir, LibraryDir, Libraries, \
             Switch, StringListOption
 
-    default_cxxflags = ['-std=c++0x']
+    default_cxxflags = ['-std=gnu++11']
 
     if 'darwin' in sys.platform:
         import platform


### PR DESCRIPTION
When trying to compile for Fedora, targeting the Power PC 64 bits little endian architecture, there are various compilation errors, starting with:

/usr/include/c++/6.3.1/type_traits:87:39: error: '__vector(4) __bool int' is not a valid type for a template non-type parameter
   typedef integral_constant<bool, true>     true_type;

Full build log link: https://kojipkgs.fedoraproject.org//work/tasks/4685/17304685/build.log

This is fixed by using the std=gnu++11 flag.

Relevant thread with some more information on the issue for another package:

https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/WZOG57J2M5UNOYZG6PUWQZGZKNCSYRHQ/
