### PR TITLE
 Fix GL interop on Windows

### DIFF
--- a/pyopencl/cffi_cl.py
+++ b/pyopencl/cffi_cl.py
@@ -732,7 +732,7 @@ def _parse_context_properties(properties):
             props.append(value.int_ptr)
 
         elif prop == getattr(context_properties, "WGL_HDC_KHR", None):
-            props.append(value)
+            props.append(ctypes.c_ssize_t(value).value)
 
         elif prop in [getattr(context_properties, key, None) for key in (
                 'CONTEXT_PROPERTY_USE_CGL_SHAREGROUP_APPLE',


### PR DESCRIPTION
Cast unsigned integer Windows handle to signed integer `cl_context_properties`

Fix OverflowError: int too big to convert:
```
Traceback (most recent call last):
  File "gl_interop_demo.py", line 38, in initialize
    + get_gl_sharing_context_properties())
  File "X:\Python35\lib\site-packages\pyopencl\cffi_cl.py", line 775, in __init__
    dev_type))
OverflowError: int too big to convert

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "gl_interop_demo.py", line 82, in <module>
    initialize()
  File "gl_interop_demo.py", line 43, in initialize
    devices = [platform.get_devices()[0]])
  File "X:\Python35\lib\site-packages\pyopencl\cffi_cl.py", line 768, in __init__
    num_devices, _devices))
OverflowError: int too big to convert
```