### PR TITLE
fix for some cases where the extreme memory sizes cause issues

### DIFF
--- a/examples/dump-performance.py
+++ b/examples/dump-performance.py
@@ -28,9 +28,11 @@ def main():
         print("latency: %g s" % perf.transfer_latency(queue, tx_type))
         for i in range(6, 31, 2):
             bs = 1 << i
-            print("bandwidth @ %d bytes: %g GB/s" % (
-                    bs, perf.transfer_bandwidth(queue, tx_type, bs)/1e9))
-
+            try:
+                result = "%g GB/s" % (perf.transfer_bandwidth(queue, tx_type, bs)/1e9)
+            except Exception as e:
+                result = "exception: %s" % e.__class__.__name__
+            print("bandwidth @ %d bytes: %s" % (bs, result))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I observed that depending upon the driver and openCL implementation, the 1GB transfer can fail.  
Rather than attempting to guess (and fail) the correct range, this patch simple handles the failures.