### PR TITLE
Fix building on macOS Sierra (10.12)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,11 @@ def get_config_schema():
                 ]
 
         default_libs = []
+        from pkg_resources import parse_version
+        if parse_version(osx_ver) < parse_version('10.12'):  # before Sierra
+            default_cxxflags = default_cxxflags + ['-stdlib=libc++']
         default_cxxflags = default_cxxflags + [
-                '-stdlib=libc++', '-mmacosx-version-min=10.7',
+                '-mmacosx-version-min=10.7',
                 '-arch', 'i386', '-arch', 'x86_64'
                 ]
 


### PR DESCRIPTION
The -stdlib=libc++ flag is no longer supported on Sierra (it is now the default option). I added a version check that adds the option for macOS versions below Sierra (10.12) and removed the option otherwise.