### PR TITLE
Support for python2 on windows

### DIFF
--- a/pyopencl/cffi_cl.py
+++ b/pyopencl/cffi_cl.py
@@ -338,7 +338,7 @@ class device_type(_ConstantsNamespace):  # noqa
                 continue
             if not name.startswith("_"):
                 bitfield = getattr(cls, name)
-                if isinstance(bitfield, int) and ((bitfield & value) == bitfield):
+                if isinstance(bitfield, six.integer_types) and ((bitfield & value) == bitfield):
                     return name
 
         if default_format is None:


### PR DESCRIPTION
This is bug-fix on the PR #212:
On windows , python2 types are "long", not "int" by default