### PR TITLE
Fix OpenGL interop segfaults on Linux

### DIFF
--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -413,7 +413,7 @@ def get_gl_sharing_context_properties():
     if sys.platform in ["linux", "linux2"]:
         from OpenGL import GLX
         props.append(
-            (ctx_props.GL_CONTEXT_KHR, gl_platform.GetCurrentContext()))
+            (ctx_props.GL_CONTEXT_KHR, GLX.glXGetCurrentContext()))
         props.append(
                 (ctx_props.GLX_DISPLAY_KHR,
                     GLX.glXGetCurrentDisplay()))


### PR DESCRIPTION
see issue #217. Some sort of type mismatch/failed cast turned the pointers into signed python integers (hence the negative numbers).
GLX.glXGetCurrentContext() returns a proper python-typed C type that gets casted correctly by the Context.\_\_init\_\_() logic.