### PR TITLE
Intel GPU (beignet-opencl-icd) compatibility fixes

### DIFF
--- a/pyopencl/scan.py
+++ b/pyopencl/scan.py
@@ -1227,8 +1227,12 @@ class GenericScanKernel(_GenericScanKernelBase):
             max_scan_wg_size = min(dev.max_work_group_size for dev in self.devices)
             wg_size_multiples = 64
 
+        # Intel beignet asserts or gives wrong results with packed structs
+        # https://bugs.freedesktop.org/show_bug.cgi?id=98717
+        # TODO: is this all Intel ICDs or only beignet?
         use_bank_conflict_avoidance = (
-                self.dtype.itemsize > 4 and self.dtype.itemsize % 8 == 0 and is_gpu)
+                self.dtype.itemsize > 4 and self.dtype.itemsize % 8 == 0
+                and is_gpu and "Intel" not in self.devices[0].platform.name)
 
         # k_group_size should be a power of two because of in-kernel
         # division by that number.

--- a/pyopencl/scan.py
+++ b/pyopencl/scan.py
@@ -1227,12 +1227,17 @@ class GenericScanKernel(_GenericScanKernelBase):
             max_scan_wg_size = min(dev.max_work_group_size for dev in self.devices)
             wg_size_multiples = 64
 
-        # Intel beignet asserts or gives wrong results with packed structs
+        # Intel beignet fails "Out of shared local memory" in test_scan int64
+        # and asserts in test_sort with this enabled:
+        # https://github.com/inducer/pyopencl/pull/238
+        # A beignet bug report (outside of pyopencl) suggests packed structs
+        # (which this is) can even give wrong results:
         # https://bugs.freedesktop.org/show_bug.cgi?id=98717
-        # TODO: is this all Intel ICDs or only beignet?
+        # TODO: does this also affect Intel Compute Runtime?
         use_bank_conflict_avoidance = (
                 self.dtype.itemsize > 4 and self.dtype.itemsize % 8 == 0
-                and is_gpu and "Intel" not in self.devices[0].platform.name)
+                and is_gpu
+                and "beignet" not in self.devices[0].platform.version.lower())
 
         # k_group_size should be a power of two because of in-kernel
         # division by that number.

--- a/test/test_clrandom.py
+++ b/test/test_clrandom.py
@@ -31,6 +31,7 @@ import pyopencl.clrandom as clrandom
 from pyopencl.tools import (  # noqa
         pytest_generate_tests_for_pyopencl
         as pytest_generate_tests)
+from pyopencl.characterize import has_double_support
 
 try:
     import faulthandler
@@ -59,6 +60,8 @@ def make_ranlux_generator(cl_ctx):
     cltypes.float4])
 def test_clrandom_dtypes(ctx_factory, rng_class, dtype):
     cl_ctx = ctx_factory()
+    if dtype == np.float64 and not has_double_support(cl_ctx.devices[0]):
+        pytest.skip("double precision not supported on this device")
     rng = rng_class(cl_ctx)
 
     size = 10

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -953,6 +953,7 @@ def test_coarse_grain_svm(ctx_factory):
     dev = ctx.devices[0]
 
     has_svm = (ctx._get_cl_version() >= (2, 0) and
+                ctx.devices[0]._get_cl_version() >= (2, 0) and
                 cl.get_cl_header_version() >= (2, 0))
 
     if dev.platform.name == "Portable Computing Language":


### PR DESCRIPTION
Fix int64 scan crash, and skip tests that exceed hardware capabilities.  (beignet is a 2.0 platform but on older hardware only a 1.2 device.)

Some of these changes take effect only after clearing the caches (rm -rf  ~/.cache/pyopencl ~/.cache/pytools/\*pyopencl\* ).

Ranlux int64 still fails its tests, but that's deprecated anyway.

Something this does _not_ fix, partly because I'm not sure at what level it would be appropriate to do so: zero-size host-to-device copies (bCL[8:8]=a[8:8]) fail with pyopencl.cffi_cl.LogicError: clEnqueueWriteBuffer failed: INVALID_VALUE