### PR TITLE
setup.py: drop pytest req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,6 @@ def main():
             install_requires=[
                 "numpy",
                 "pytools>=2017.6",
-                "pytest>=2",
                 "decorator>=3.2.0",
                 "cffi>=1.1.0",
                 "appdirs>=1.4.0",


### PR DESCRIPTION
It is not needed in runtime at all.