### PR TITLE
removed exception "CommandQueue failed: INVALID_VALUE"

### DIFF
--- a/src/wrap_cl.hpp
+++ b/src/wrap_cl.hpp
@@ -1356,11 +1356,6 @@ namespace pyopencl
         else
         {
 #if PYOPENCL_CL_VERSION >= 0x2000
-            throw error("CommandQueue", CL_INVALID_VALUE,
-                "queue properties given as an iterable, "
-                "which is only allowed when PyOpenCL was built "
-                "against an OpenCL 2+ header");
-
           if (hex_plat_version  < 0x2000)
           {
             std::cerr <<


### PR DESCRIPTION
Hi.
```
properties = cl.command_queue_properties.OUT_OF_ORDER_EXEC_MODE_ENABLE\
            | cl.command_queue_properties.ON_DEVICE
queue_properties = [cl.queue_properties.PROPERTIES, properties,
                    cl.queue_properties.SIZE, 1000000]
device_queue = cl.CommandQueue(context, device, queue_properties)
```

This code throws exception - "pyopencl._cl.LogicError: CommandQueue failed: INVALID_VALUE - queue properties given as an iterable, which is only allowed when PyOpenCL was built against an OpenCL 2+ header"

I removed the exception and code works fine. Does this exception have value or added by mistake?