### PR TITLE
Make particle example work without PyOpenGL_accelerate

### DIFF
--- a/examples/gl_particle_animation.py
+++ b/examples/gl_particle_animation.py
@@ -143,8 +143,8 @@ cl_velocity = cl.Buffer(context, mf.COPY_HOST_PTR, hostbuf=np_velocity)
 cl_start_position = cl.Buffer(context, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=np_position)
 cl_start_velocity = cl.Buffer(context, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=np_velocity)
 
-cl_gl_position = cl.GLBuffer(context, mf.READ_WRITE, int(gl_position.buffer))
-cl_gl_color = cl.GLBuffer(context, mf.READ_WRITE, int(gl_color.buffer))
+cl_gl_position = cl.GLBuffer(context, mf.READ_WRITE, int(gl_position))
+cl_gl_color = cl.GLBuffer(context, mf.READ_WRITE, int(gl_color))
 
 kernel = """__kernel void particle_fountain(__global float4* position, 
                                             __global float4* color, 


### PR DESCRIPTION
vbo.buffer nor vbo.buffers aren't normally used by external code
The normal way to get the ID of the VBO is int(vbo)
See https://github.com/inducer/pyopencl/issues/196