### PR TITLE
Add travis-ci pipeline to build python wheels for Linux (PEP513)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 notifications:
   email: false
-branches:
-  only:
-    - master
 if: tag IS present
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 notifications:
   email: false
+branches:
+  only:
+    - master
+if: tag IS present
 matrix:
   include:
   - sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+notifications:
+  email: false
+matrix:
+  include:
+  - sudo: required
+    services:
+      - docker
+    env:
+      - DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+  - sudo: required
+    services:
+      - docker
+    env:
+      - DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+      - PRE_CMD=linux32
+install:
+  - docker pull $DOCKER_IMAGE
+script:
+  - pwd
+  - ls -la
+  - docker run --rm -v `pwd`:/io -e TWINE_USERNAME -e TWINE_PASSWORD $DOCKER_IMAGE $PRE_CMD /io/travis/build-wheels.sh
+  - ls wheelhouse/

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ def main():
         print("https://pypi.python.org/pypi/pyopencl")
         sys.exit(1)
 
-    setup(name="pyopencl-gm",
+    setup(name="pyopencl",
             # metadata
             version=ver_dic["VERSION_TEXT"],
             description="Python wrapper for OpenCL",

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ def main():
         print("https://pypi.python.org/pypi/pyopencl")
         sys.exit(1)
 
-    setup(name="pyopencl-gmagno",
+    setup(name="pyopencl-gm",
             # metadata
             version=ver_dic["VERSION_TEXT"],
             description="Python wrapper for OpenCL",

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ def main():
         print("https://pypi.python.org/pypi/pyopencl")
         sys.exit(1)
 
-    setup(name="pyopencl",
+    setup(name="pyopencl-gmagno",
             # metadata
             version=ver_dic["VERSION_TEXT"],
             description="Python wrapper for OpenCL",

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -26,7 +26,7 @@ done
 
 
 /opt/python/cp37-cp37m/bin/pip install twine
-for WHEEL in /io/wheelhouse/pyopencl-gm*.whl; do
+for WHEEL in /io/wheelhouse/pyopencl_gm*.whl; do
     # /opt/python/cp37-cp37m/bin/twine upload --repository-url https://test.pypi.org/legacy/ "${WHEEL}"
     /opt/python/cp37-cp37m/bin/twine upload -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" "${WHEEL}"
 done

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -26,7 +26,7 @@ done
 
 
 /opt/python/cp37-cp37m/bin/pip install twine
-for WHEEL in /io/wheelhouse/gmagno_pyopencl*.whl; do
+for WHEEL in /io/wheelhouse/pyopencl-gmagno*.whl; do
     # /opt/python/cp37-cp37m/bin/twine upload --repository-url https://test.pypi.org/legacy/ "${WHEEL}"
     /opt/python/cp37-cp37m/bin/twine upload -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" "${WHEEL}"
 done

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -26,7 +26,7 @@ done
 
 
 /opt/python/cp37-cp37m/bin/pip install twine
-for WHEEL in /io/wheelhouse/pyopencl-gmagno*.whl; do
+for WHEEL in /io/wheelhouse/pyopencl-gm*.whl; do
     # /opt/python/cp37-cp37m/bin/twine upload --repository-url https://test.pypi.org/legacy/ "${WHEEL}"
     /opt/python/cp37-cp37m/bin/twine upload -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" "${WHEEL}"
 done

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e -x
+
+export PYHOME=/home
+export CL_H=${PYHOME}/cl_h
+export CL_ICDLOAD=${PYHOME}/cl_icdload
+
+cd ${PYHOME}
+yum install -y git cmake
+git clone https://github.com/KhronosGroup/OpenCL-Headers.git ${CL_H}
+git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader.git ${CL_ICDLOAD}
+ln -s ${CL_H}/CL /usr/include/CL
+make -C ${CL_ICDLOAD}
+cp -r ${CL_ICDLOAD}/build/lib/lib* /usr/lib
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install numpy pybind11 mako
+    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done
+
+
+/opt/python/cp37-cp37m/bin/pip install twine
+for WHEEL in /io/wheelhouse/gmagno_pyopencl*.whl; do
+    # /opt/python/cp37-cp37m/bin/twine upload --repository-url https://test.pypi.org/legacy/ "${WHEEL}"
+    /opt/python/cp37-cp37m/bin/twine upload -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" "${WHEEL}"
+done

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -24,9 +24,8 @@ for whl in wheelhouse/*.whl; do
     auditwheel repair "$whl" -w /io/wheelhouse/
 done
 
-
 /opt/python/cp37-cp37m/bin/pip install twine
 for WHEEL in /io/wheelhouse/pyopencl_gm*.whl; do
-    # /opt/python/cp37-cp37m/bin/twine upload --repository-url https://test.pypi.org/legacy/ "${WHEEL}"
-    /opt/python/cp37-cp37m/bin/twine upload -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" "${WHEEL}"
+    # /opt/python/cp37-cp37m/bin/twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ "${WHEEL}"
+    /opt/python/cp37-cp37m/bin/twine upload --skip-existing -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" "${WHEEL}"
 done

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -25,7 +25,16 @@ for whl in wheelhouse/*.whl; do
 done
 
 /opt/python/cp37-cp37m/bin/pip install twine
-for WHEEL in /io/wheelhouse/pyopencl_gm*.whl; do
-    # /opt/python/cp37-cp37m/bin/twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ "${WHEEL}"
-    /opt/python/cp37-cp37m/bin/twine upload --skip-existing -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" "${WHEEL}"
+for WHEEL in /io/wheelhouse/pyopencl*.whl; do
+    # dev
+    # /opt/python/cp37-cp37m/bin/twine upload \
+    #     --skip-existing \
+    #     --repository-url https://test.pypi.org/legacy/ \
+    #     -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" \
+    #     "${WHEEL}"
+    # prod
+    /opt/python/cp37-cp37m/bin/twine upload \
+        --skip-existing \
+        -u "${TWINE_USERNAME}" -p "${TWINE_PASSWORD}" \
+        "${WHEEL}"
 done


### PR DESCRIPTION
Suggestion to add a travis-ci pipeline to build python wheels for Linux (PEP513). For more context please check issue: #263 .

Just a few notes:
- A travis account is needed, and the PyPI account details should be passed as environment variables. This can be configured using the web interface and setting: TWINE_USERNAME and TWINE_PASSWORD. Please check the following image.

![image](https://user-images.githubusercontent.com/46817915/51860173-1c2abf80-2320-11e9-903a-7458678cb2f3.png)

- The job is currently pulling `OpenCL-Headers` and `OpenCL-ICD-Loader`, and building the latter with their latest version. I am not sure this is the desired behavior and should be reviewed.

- The job is triggered by tagged commits only, to avoid redundant builds.

- It probably makes sense, at some point, to replace this travis job by a gitlab-ci one as it seems Gitlab is what people are using(?)

Cheers,
