### PR TITLE
Wheels: support ocl binary distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 notifications:
   email: false
-if: tag IS present
 matrix:
   include:
   - sudo: required

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -95,6 +95,32 @@ On macOS, the packaging of PyOpenCL for Conda Forge relies on the
 and it is packaged so that the OpenCL drivers built into the operating system
 are automatically available, in addition to other ICDs installed manually.
 
+Installing from PyPI with Linux wheels
+--------------------------------------
+
+PyOpenCL distributes manylinux1 wheels in PyPI. These wheels are compatible with
+GLIBC>=2.5 based distributions.
+
+On Linux, type
+
+#.  ``pip install pyopencl``
+
+The wheels comes with OCL-ICD bundled and configured to use any OpenCL implementation
+supporting ICD interface installed in :file:`/etc/OpenCL/vendors`
+
+You can also install the following CPU based OpenCL implementation using pip shipped as binary
+wheels. Note that pyopencl has to be installed using a wheel for pyopencl to recognize these
+wheels.
+
+To install pyopencl with pocl, a CPU based implementation do,
+
+#.  ``pip install pyopencl[pocl]``
+
+To install pyopencl with oclgrind, an OpenCL debugger do,
+
+#.  ``pip install pyopencl[oclgrind]``
+
+
 Installing from source
 ----------------------
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -32,6 +32,9 @@ from pyopencl.version import VERSION, VERSION_STATUS, VERSION_TEXT  # noqa
 import logging
 logger = logging.getLogger(__name__)
 
+import os
+os.environ["PYOPENCL_HOME"] = os.path.dirname(os.path.abspath(__file__))
+
 try:
     import pyopencl._cl as _cl
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ def main():
                 ],
             extras_require={
                 'pocl':  ["pocl_binary_distribution>=1.2"],
-            }
+            },
             include_package_data=True,
             package_data={
                     "pyopencl": [

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,9 @@ def main():
                 "six>=1.9.0",
                 # "Mako>=0.3.6",
                 ],
-
+            extras_require={
+                'pocl':  ["pocl_binary_distribution>=1.2"],
+            }
             include_package_data=True,
             package_data={
                     "pyopencl": [

--- a/setup.py
+++ b/setup.py
@@ -260,6 +260,7 @@ def main():
                 ],
             extras_require={
                 'pocl':  ["pocl_binary_distribution>=1.2"],
+                'oclgrind':  ["oclgrind_binary_distribution>=18.3"],
             },
             include_package_data=True,
             package_data={

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -54,6 +54,7 @@ done
 /opt/python/cp37-cp37m/bin/python /io/travis/fix-wheel.py /deps/ocl-icd/COPYING
 
 if [[ "${TWINE_USERNAME}" == "" ]]; then
+    echo "TWINE_USERNAME not set. Skipping uploading wheels"
     exit 0
 fi
 

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -18,8 +18,8 @@ git clone --branch v2.2.12 https://github.com/OCL-dev/ocl-icd
 cd ocl-icd
 curl -L -O https://raw.githubusercontent.com/conda-forge/ocl-icd-feedstock/master/recipe/install-headers.patch
 git apply install-headers.patch
-curl -L -O https://github.com/isuruf/ocl-icd/commit/c28a6f39634d73c844d70b12120b38c40b17aecc.patch
-git apply c28a6f39634d73c844d70b12120b38c40b17aecc.patch
+curl -L -O https://github.com/isuruf/ocl-icd/commit/76fab891c277886ef88af73c57328f8a47bdb6a4.patch
+git apply 76fab891c277886ef88af73c57328f8a47bdb6a4.patch
 autoreconf -i
 chmod +x configure
 ./configure --prefix=/usr

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -18,6 +18,8 @@ git clone --branch v2.2.12 https://github.com/OCL-dev/ocl-icd
 cd ocl-icd
 curl -L -O https://raw.githubusercontent.com/conda-forge/ocl-icd-feedstock/master/recipe/install-headers.patch
 git apply install-headers.patch
+curl -L -O https://github.com/isuruf/ocl-icd/commit/c28a6f39634d73c844d70b12120b38c40b17aecc.patch
+git apply c28a6f39634d73c844d70b12120b38c40b17aecc.patch
 autoreconf -i
 chmod +x configure
 ./configure --prefix=/usr

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -53,6 +53,10 @@ done
 /opt/python/cp37-cp37m/bin/pip install delocate
 /opt/python/cp37-cp37m/bin/python /io/travis/fix-wheel.py /deps/ocl-icd/COPYING
 
+if [[ "${TWINE_USERNAME}" == "" ]]; then
+    exit 0
+fi
+
 /opt/python/cp37-cp37m/bin/pip install twine
 for WHEEL in /io/wheelhouse/pyopencl*.whl; do
     # dev


### PR DESCRIPTION
Scripts for building pocl and oclgrind are at https://github.com/isuruf/ocl-wheels.

cc @gmagno