### PR TITLE
Add cfloat_t and cdouble_t to cltypes

### DIFF
--- a/pyopencl/cltypes.py
+++ b/pyopencl/cltypes.py
@@ -42,6 +42,8 @@ ulong = np.uint64
 half = np.float16
 float = np.float32
 double = np.float64
+cfloat_t = np.complex64
+cdouble_t = np.complex128
 
 
 # {{{ vector types


### PR DESCRIPTION
If I understand correctly, it is not possible to create vectors of cfloat_t or cdouble_t at the moment, so I have not added any corresponding vector types.