### PR TITLE
Fix slow import of pyopencl

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -260,13 +260,15 @@ def _find_pyopencl_include_path():
         # Try to find the include path in the same directory as this file
         include_path = join(abspath(dirname(__file__)), "cl")
         if not exists(include_path):
-            raise IOError()
+            raise IOError("unable to find pyopencl include path")
     except Exception:
         # Try to find the resource with pkg_resources (the recommended
         # setuptools approach). This is very slow.
         from pkg_resources import Requirement, resource_filename
         include_path = resource_filename(
                 Requirement.parse("pyopencl"), "pyopencl/cl")
+        if not exists(include_path):
+            raise IOError("unable to find pyopencl include path")
 
     # Quote the path if it contains a space and is not quoted already.
     # See https://github.com/inducer/pyopencl/issues/250 for discussion.

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -264,8 +264,7 @@ def _find_pyopencl_include_path():
     except Exception:
         # Try to find the resource with pkg_resources (the recommended
         # setuptools approach). This is very slow.
-        from pkg_resources import (Requirement, resource_filename,
-                                   DistributionNotFound)
+        from pkg_resources import Requirement, resource_filename
         include_path = resource_filename(
                 Requirement.parse("pyopencl"), "pyopencl/cl")
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -255,23 +255,19 @@ def compiler_output(text):
 # {{{ find pyopencl shipped source code
 
 def _find_pyopencl_include_path():
-    from pkg_resources import Requirement, resource_filename, DistributionNotFound
+    from os.path import join, abspath, dirname, exists
     try:
+        # Try to find the include path in the same directory as this file
+        include_path = join(abspath(dirname(__file__)), "cl")
+        if not exists(include_path):
+            raise IOError()
+    except Exception:
         # Try to find the resource with pkg_resources (the recommended
-        # setuptools approach)
+        # setuptools approach). This is very slow.
+        from pkg_resources import (Requirement, resource_filename,
+                                   DistributionNotFound)
         include_path = resource_filename(
                 Requirement.parse("pyopencl"), "pyopencl/cl")
-    except DistributionNotFound:
-        # If pkg_resources can't find it (e.g. if the module is part of a
-        # frozen application), try to find the include path in the same
-        # directory as this file
-        from os.path import join, abspath, dirname, exists
-
-        include_path = join(abspath(dirname(__file__)), "cl")
-        # If that doesn't exist, just re-raise the exception caught from
-        # resource_filename.
-        if not exists(include_path):
-            raise
 
     # Quote the path if it contains a space and is not quoted already.
     # See https://github.com/inducer/pyopencl/issues/250 for discussion.


### PR DESCRIPTION
On my Windows workstation, `import pyopencl` takes 3.2 s, more than 3 s of which are spent in `import pkg_resources`.

Importing `pkg_resources` is known to be excruciatingly slow. See https://github.com/pypa/setuptools/issues/510

This PR just reverses the order of the methods used to find the cl include directory. I'm not sure if `pkg_resources` is really necessary here at all (?)