### PR TITLE
Add Device.hashable_model_and_version_identifier, deprecate Device.pe…

### DIFF
--- a/doc/runtime_platform.rst
+++ b/doc/runtime_platform.rst
@@ -58,6 +58,18 @@ Device
     .. automethod:: from_int_ptr
     .. autoattribute:: int_ptr
 
+    .. attribute :: hashable_model_and_version_identifier
+
+        An unspecified data type that can be used to (as precisely as possible,
+        given identifying information available in OpenCL) identify a given
+        model and software stack version of a compute device. Note that this
+        identifier does not differentiate between different instances of the
+        same device installed in a single host.
+
+        The returned data type is hashable.
+
+        .. versionadded:: 2020.1
+
     .. method:: create_sub_devices(properties)
 
         *properties* is an array of one (or more) of the forms::

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -633,13 +633,22 @@ def _add_functionality():
         return "<pyopencl.Device '%s' on '%s' at 0x%x>" % (
                 self.name.strip(), self.platform.name.strip(), self.int_ptr)
 
+    def device_hashable_model_and_version_identifier(self):
+        return ("v1", self.vendor, self.vendor_id, self.name, self.version)
+
     def device_persistent_unique_id(self):
-        return (self.vendor, self.vendor_id, self.name, self.version)
+        from warnings import warn
+        warn("Device.persistent_unique_id is deprecated. "
+                "Use Device.hashable_model_and_version_identifier instead.",
+                DeprecationWarning, stacklevel=2)
+        return device_hashable_model_and_version_identifier(self)
 
     Device.__repr__ = device_repr
 
     # undocumented for now:
     Device._get_cl_version = generic_get_cl_version
+    Device.hashable_model_and_version_identifier = property(
+            device_hashable_model_and_version_identifier)
     Device.persistent_unique_id = property(device_persistent_unique_id)
 
     # }}}

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -56,6 +56,9 @@ def test_get_info(ctx_factory):
     device, = ctx.devices
     platform = device.platform
 
+    device.persistent_unique_id
+    device.hashable_model_and_version_identifier
+
     failure_count = [0]
 
     pocl_quirks = [


### PR DESCRIPTION
…rsistent_unique_id (closes gh-327)