### PR TITLE
Fix platform detection for pocl

### DIFF
--- a/pyopencl/characterize/__init__.py
+++ b/pyopencl/characterize/__init__.py
@@ -282,11 +282,11 @@ def get_simd_group_size(dev, type_size):
 
     lc_plat_vendor = dev.platform.vendor.lower()
     lc_dev_vendor = dev.vendor.lower()
-    if "nvidia" in lc_vendor or "nvidia" in lc_real_vendor:
+    if "nvidia" in lc_plat_vendor or "nvidia" in lc_dev_vendor:
         return 32
 
-    if ("advanced micro" in lc_vendor or "ati" in lc_vendor
-      or "advanced micro" in lc_real_vendor or "ati" in lc_real_vendor):
+    if ("advanced micro" in lc_plat_vendor or "ati" in lc_plat_vendor
+      or "advanced micro" in lc_dev_vendor or "ati" in lc_dev_vendor):
         if dev.type & cl.device_type.GPU:
             # Tomasz Rybak says, in response to reduction misbehaving on the AMD
             # 'Loveland' APU:

--- a/pyopencl/characterize/__init__.py
+++ b/pyopencl/characterize/__init__.py
@@ -281,12 +281,14 @@ def get_simd_group_size(dev, type_size):
         pass
 
     lc_vendor = dev.platform.vendor.lower()
-    if "nvidia" in lc_vendor:
+    lc_real_vendor = dev.vendor.lower()
+    if "nvidia" in lc_vendor or "nvidia" in lc_real_vendor:
         return 32
 
-    if ("advanced micro" in lc_vendor or "ati" in lc_vendor):
+    if ("advanced micro" in lc_vendor or "ati" in lc_vendor or
+      "advanced micro" in lc_real_vendor or "ati" in lc_real_vendor):
         if dev.type & cl.device_type.GPU:
-            # Tomasz Rybak says, in response to reduction mishbehaving on the AMD
+            # Tomasz Rybak says, in response to reduction misbehaving on the AMD
             # 'Loveland' APU:
             #
             #    Like in CUDA reduction bug (related to Fermi) it again seems

--- a/pyopencl/characterize/__init__.py
+++ b/pyopencl/characterize/__init__.py
@@ -280,7 +280,7 @@ def get_simd_group_size(dev, type_size):
     except Exception:
         pass
 
-    lc_vendor = dev.platform.vendor.lower()
+    lc_plat_vendor = dev.platform.vendor.lower()
     lc_dev_vendor = dev.vendor.lower()
     if "nvidia" in lc_vendor or "nvidia" in lc_real_vendor:
         return 32

--- a/pyopencl/characterize/__init__.py
+++ b/pyopencl/characterize/__init__.py
@@ -285,8 +285,8 @@ def get_simd_group_size(dev, type_size):
     if "nvidia" in lc_vendor or "nvidia" in lc_real_vendor:
         return 32
 
-    if ("advanced micro" in lc_vendor or "ati" in lc_vendor or
-      "advanced micro" in lc_real_vendor or "ati" in lc_real_vendor):
+    if ("advanced micro" in lc_vendor or "ati" in lc_vendor
+      or "advanced micro" in lc_real_vendor or "ati" in lc_real_vendor):
         if dev.type & cl.device_type.GPU:
             # Tomasz Rybak says, in response to reduction misbehaving on the AMD
             # 'Loveland' APU:

--- a/pyopencl/characterize/__init__.py
+++ b/pyopencl/characterize/__init__.py
@@ -281,7 +281,7 @@ def get_simd_group_size(dev, type_size):
         pass
 
     lc_vendor = dev.platform.vendor.lower()
-    lc_real_vendor = dev.vendor.lower()
+    lc_dev_vendor = dev.vendor.lower()
     if "nvidia" in lc_vendor or "nvidia" in lc_real_vendor:
         return 32
 


### PR DESCRIPTION
In pocl, "dev.platform.vendor" is "The pocl project".