### PR TITLE
Fix get_pyopencl_fixture_arg_values to correctly enumerate over all devices

### DIFF
--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -282,14 +282,14 @@ def get_pyopencl_fixture_arg_values():
 
     arg_values = []
     for platform, devices in get_test_platforms_and_devices():
-        arg_dict = {"platform": platform}
-
         for device in devices:
-            arg_dict["device"] = device
-            arg_dict["ctx_factory"] = _ContextFactory(device)
-            arg_dict["ctx_getter"] = _ContextFactory(device)
-
-        arg_values.append(arg_dict)
+            arg_dict = {
+                "platform": platform,
+                "device": device,
+                "ctx_factory": _ContextFactory(device),
+                "ctx_getter": _ContextFactory(device)
+            }
+            arg_values.append(arg_dict)
 
     def idfn(val):
         if isinstance(val, cl.Platform):


### PR DESCRIPTION
I noticed the `pytest_generate_tests_for_pyopencl` functionality was behaving strangely, so I looked into it and found/fixed what I think is a bug in `get_pyopencl_fixture_arg_values`.

The old code enumerated over platforms correctly, but it only picked up one device from each (the last one in the list). On lassen, this manifested as the tests only running once instead of the expected 5 times (CPU + 4 GPUs). With this fix, they now run on all of the devices.