### PR TITLE
Fix get_sub_group_info version requirement

### DIFF
--- a/src/wrap_cl_part_2.cpp
+++ b/src/wrap_cl_part_2.cpp
@@ -478,7 +478,7 @@ void pyopencl_expose_part_2(py::module &m)
       .def(py::self != py::self)
       .def("__hash__", &cls::hash)
       PYOPENCL_EXPOSE_TO_FROM_INT_PTR(cl_kernel)
-#if PYOPENCL_CL_VERSION >= 0x1020
+#if PYOPENCL_CL_VERSION >= 0x2010
       .def("get_sub_group_info", &cls::get_sub_group_info,
           py::arg("device"),
           py::arg("param"),


### PR DESCRIPTION
I think there's a typo on one of the version thresholds for `get_sub_group_info`, which [should be 2.1](https://www.khronos.org/registry/OpenCL/specs/2.2/html/OpenCL_Ext.html#cl_khr_subgroups) ([this line](https://github.com/inducer/pyopencl/blob/fe2451a4b2f9a6e6bf18c32b29c509900f59d28e/src/wrap_cl.hpp#L4553) has it right, I think). Building locally with my v1.2 headers (thanks, NVIDIA) failed as a result.