### PR TITLE
Add note to install docs about mixing conda forge and pypi installations

### DIFF
--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -94,6 +94,10 @@ qualified path names of the shared library providing the OpenCL driver.
 
     Note that you should replace ``ENVIRONMENTNAME`` with the name of your environment,
     shown between parentheses on your command line prompt.
+    This path (for the currently-active conda environment) can be obtained from the
+    environment variable ``CONDA_PREFIX``, i.e.,
+
+    :file:`$CONDA_PREFIX/etc/OpenCL/vendors`.
 
 On Linux, if you have other OpenCL drivers installed (such as for your GPU), those will be
 in :file:`/etc/OpenCL/vendors`. You can make them work with PyOpenCL from Conda Forge
@@ -101,7 +105,9 @@ by using the command::
 
     conda install ocl-icd-system
 
-will make sure these system-wide ICDs are also visible  in your conda environment.
+will make sure these system-wide ICDs are also visible in your conda environment.
+As an alternative, one may manually copy ICD files from :file:`/etc/OpenCL/vendors` into,
+e.g., :file:`$CONDA_PREFIX/etc/OpenCL/vendors`.
 
 If you are looking for more information, see `ocl-icd
 <https://github.com/OCL-dev/ocl-icd>`_ and its documentation. Ocl-icd is the

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -97,7 +97,7 @@ qualified path names of the shared library providing the OpenCL driver.
     This path (for the currently-active conda environment) can be obtained from the
     environment variable ``CONDA_PREFIX``, i.e.,
 
-    :file:`$CONDA_PREFIX/etc/OpenCL/vendors`.
+    :file:`$CONDA_PREFIX/etc/OpenCL/vendors` (once the Conda environment is activated).
 
 On Linux, if you have other OpenCL drivers installed (such as for your GPU), those will be
 in :file:`/etc/OpenCL/vendors`. You can make them work with PyOpenCL from Conda Forge

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -138,6 +138,12 @@ To install pyopencl with oclgrind, an OpenCL debugger do,
 
 #.  ``pip install pyopencl[oclgrind]``
 
+.. note::
+
+    Avoid mixing components installed from Conda Forge and PyPI.
+    For example, installing PyOpenCL from pip followed by OCL-ICD from Conda Forge can
+    redirect the ICD loader, removing access to system-wide ICDs.
+
 
 Installing from source
 ----------------------


### PR DESCRIPTION
Per title. Closes #399.

While I'm here, I propose two more additions (for installations in a conda environment):

1. `/WHERE/YOU/INSTALLED/MINICONDA/envs/ENVIRONMENTNAME/` can be obtained by `$CONDA_PREFIX` (for the active environment)
2. As an alternative to installing `ocl-icd-system`, system ICD files can be manually copied from `/etc/OpenCL/vendors` into `$CONDA_PREFIX/etc/OpenCL/vendors/`.

Thoughts?