### PR TITLE
Fix build on macos X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,7 @@ def get_config_schema():
 
         default_libs = []
         default_cxxflags = default_cxxflags + [
-                "-stdlib=libc++", "-mmacosx-version-min=10.7",
-                "-arch', 'i386", "-arch", "x86_64", "-arch", "arm64",
-                ]
+                "-stdlib=libc++", "-mmacosx-version-min=10.7"]
 
         from os.path import isdir
         for srp in sysroot_paths:


### PR DESCRIPTION
This PR proposes a fix for building pyopencl on macos 10

It also fixes a typo on string quotes introduced in https://github.com/inducer/pyopencl/commit/3823b9ff6ab1c8ad9233cb3e380ddf3e2d8adbe0

I tested it on macos 10.12, but I can't test it on macos 11...

closes #422