### PR TITLE
fix SLOT_ID name

### DIFF
--- a/doc/make_constants.py
+++ b/doc/make_constants.py
@@ -111,7 +111,7 @@ const_ext_lookup = {
             "INTEGRATED_MEMORY_NV": nv_devattr,
             "ATTRIBUTE_ASYNC_ENGINE_COUNT_NV": nv_devattr,
             "PCI_BUS_ID_NV": nv_devattr,
-            "PCI_BUS_SLOT_NV": nv_devattr,
+            "PCI_SLOT_ID_NV": nv_devattr,
 
             "DOUBLE_FP_CONFIG":
             ("cl_khr_fp64", "2011.1"),


### PR DESCRIPTION
Strangely, it already looks correct at https://documen.tician.de/pyopencl/runtime_const.html#pyopencl.device_info.PCI_SLOT_ID_NV