### PR TITLE
Fix dead link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,7 +39,7 @@ Tutorials
 =========
 
 * Gaston Hillar's `two-part article series
-  <http://www.drdobbs.com/open-source/easy-opencl-with-python/240162614>`_
+  <http://web.archive.org/web/20190707171427/www.drdobbs.com/open-source/easy-opencl-with-python/240162614>`_
   in Dr. Dobb's Journal provides a friendly introduction to PyOpenCL.
 * `Simon McIntosh-Smith <http://www.cs.bris.ac.uk/~simonm/>`_
   and `Tom Deakin <http://www.tomdeakin.com/>`_'s course


### PR DESCRIPTION
It appears Dr. Dobbs has done some spring-cleaning on his blog.

I chose that particular snapshot because it's adjacent to the last [snapshot of Part 2](http://web.archive.org/web/20190718032812/www.drdobbs.com/open-source/easy-opencl-with-python/240162614?pgno=2), to avoid the Next link accidentally glomming onto an error page in the future.