### PR TITLE
cl.array.Array.ravel: takes order as an argument

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -1759,9 +1759,9 @@ class Array:
                 data=self.base_data, offset=self.offset, shape=shape,
                 strides=tuple(newstrides))
 
-    def ravel(self):
+    def ravel(self, order="C"):
         """Returns flattened array containing the same data."""
-        return self.reshape(self.size)
+        return self.reshape(self.size, order=order)
 
     def view(self, dtype=None):
         """Returns view of array with the same data. If *dtype* is different

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -1583,6 +1583,26 @@ def test_slice_copy(ctx_factory):
         y.copy()
 
 
+@pytest.mark.parametrize("order", ("C", "F"))
+def test_ravel(ctx_factory, order):
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+
+    x = np.random.randn(10, 4)
+
+    if order == "F":
+        x = np.asfortranarray(x)
+    elif order == "C":
+        pass
+    else:
+        raise AssertionError
+
+    x_cl = cl.array.to_device(cq, x)
+
+    np.testing.assert_allclose(x_cl.ravel(order=order).get(),
+                               x.ravel(order=order))
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Numpy's [ravel](https://numpy.org/doc/stable/reference/generated/numpy.ravel.html) takes an order argument, so it makes sense that pyopencl's array also take one. It's quite convenient to flatten F-contiguous nd-arrays (n > 1).