### PR TITLE
jdocs: fix a few simple typos

### DIFF
--- a/aksetup_helper.py
+++ b/aksetup_helper.py
@@ -936,7 +936,7 @@ def has_flag(compiler, flagname):
 def cpp_flag(compiler):
     """Return the -std=c++[11/14] compiler flag.
 
-    The c++14 is prefered over c++11 (when it is available).
+    The c++14 is preferred over c++11 (when it is available).
     """
     if has_flag(compiler, "-std=gnu++14"):
         return "-std=gnu++14"

--- a/doc/types.rst
+++ b/doc/types.rst
@@ -23,7 +23,7 @@ see that a cl_long is 64 bit unsigned integer. Use the module as follows:
 
 .. note::
 
-    The OpenCL type ``bool`` does not have a correpsonding :mod:`numpy` type defined here,
+    The OpenCL type ``bool`` does not have a corresponding :mod:`numpy` type defined here,
     because OpenCL does not specify the in-memory representation (or even the storage
     size) for this type.
 

--- a/examples/black-hole-accretion.py
+++ b/examples/black-hole-accretion.py
@@ -23,7 +23,7 @@
 # - Herve Aussel for his part of code of black body spectrum
 # - Didier Pelat for his help to perform this work
 # - Jean-Pierre Luminet for his article published in 1979
-# - Numerical Recipies for Runge Kutta recipies
+# - Numerical Recipes for Runge Kutta recipes
 # - Luc Blanchet for his disponibility about my questions in General Relativity
 # - Pierre Lena for his passion about science and vulgarisation
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1634,7 +1634,7 @@ def enqueue_copy(queue, dest, src, **kwargs):
         The size of the transfer is controlled by the size of the
         of the host-side buffer. If the host-side buffer
         is a :class:`numpy.ndarray`, you can control the transfer size by
-        transfering into a smaller 'view' of the target array, like this::
+        transferring into a smaller 'view' of the target array, like this::
 
             cl.enqueue_copy(queue, large_dest_numpy_array[:15], src_buffer)
 
@@ -1960,7 +1960,7 @@ def enqueue_svm_memfill(queue, dest, pattern, byte_count=None, wait_for=None):
 def enqueue_svm_migratemem(queue, svms, flags, wait_for=None):
     """
     :arg svms: a collection of Python buffer objects (e.g. :mod:`numpy`
-        arrrays), optionally wrapped in :class:`SVM` objects.
+        arrays), optionally wrapped in :class:`SVM` objects.
     :arg flags: a combination of :class:`mem_migration_flags`
 
     |std-enqueue-blurb|

--- a/pyopencl/cl/pyopencl-random123/array.h
+++ b/pyopencl/cl/pyopencl-random123/array.h
@@ -146,7 +146,7 @@ inline R123_CUDA_DEVICE value_type assemble_from_u32(uint32_t *p32){
            constant-folded/optimized away by the compiler, so only the  \
            overflow tests (!!v[i]) remain to be done at runtime.  For  \
            small values of N, it would be better to do this as an       \
-           uncondtional sequence of adc.  An experiment/optimization    \
+           unconditional sequence of adc.  An experiment/optimization    \
            for another day...                                           \
            N.B.  The weird subscripting: v[_N>3?3:0] is to silence      \
            a spurious error from icpc                                   \


### PR DESCRIPTION
There are small typos in:
- aksetup_helper.py
- doc/types.rst
- examples/black-hole-accretion.py
- pyopencl/__init__.py
- pyopencl/cl/pyopencl-random123/array.h

Fixes:
- Should read `unconditional` rather than `uncondtional`.
- Should read `transferring` rather than `transfering`.
- Should read `recipes` rather than `recipies`.
- Should read `preferred` rather than `prefered`.
- Should read `corresponding` rather than `correpsonding`.
- Should read `arrays` rather than `arrrays`.

Closes #500