### PR TITLE
Added NotImplemented error to Array.concatenate

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -2605,8 +2605,8 @@ def multi_put(arrays, dest_indices, dest_shape=None, out=None, queue=None,
 def concatenate(arrays, axis=0, queue=None, allocator=None):
     """
     Return a :class:`Array` that is a concatenation of the input tuple of 
-    :class:`Array` along :arg axis:. **Warning** Only axis = 0 has been 
-    implemented.
+    :class:`Array` along :arg axis:. **Warning** The current implementation
+    allows only concatenation of row-major arrays along axis = 0.
 
     .. versionadded:: 2013.1
     """
@@ -2615,8 +2615,8 @@ def concatenate(arrays, axis=0, queue=None, allocator=None):
     shape = None
     if axis != 0:
         raise NotImplementedError("Axis != 0. "+
-                                  "To be implementedk when Array.setitems " +
-                                  "allows values with different stride".)
+                                  "To be implemented when Array.setitems " +
+                                  "allows values with different stride.")
 
 
     for i_ary, ary in enumerate(arrays):

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -2604,7 +2604,7 @@ def multi_put(arrays, dest_indices, dest_shape=None, out=None, queue=None,
 
 def concatenate(arrays, axis=0, queue=None, allocator=None):
     """
-    Return a :class:`Array` that is a concatenation of the input tuple of 
+    Return a :class:`Array` that is a concatenation of the input tuple of
     :class:`Array` along :arg axis:. **Warning** The current implementation
     allows only concatenation of row-major arrays along axis = 0.
 
@@ -2614,10 +2614,9 @@ def concatenate(arrays, axis=0, queue=None, allocator=None):
 
     shape = None
     if axis != 0:
-        raise NotImplementedError("Axis != 0. "+
-                                  "To be implemented when Array.setitems " +
-                                  "allows values with different stride.")
-
+        raise NotImplementedError("Axis != 0. "
+                                  + "To be implemented when Array.setitems "
+                                  + "allows values with different stride.")
 
     for i_ary, ary in enumerate(arrays):
         queue = queue or ary.queue

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -2604,11 +2604,20 @@ def multi_put(arrays, dest_indices, dest_shape=None, out=None, queue=None,
 
 def concatenate(arrays, axis=0, queue=None, allocator=None):
     """
+    Return a :class:`Array` that is a concatenation of the input tuple of 
+    :class:`Array` along :arg axis:. **Warning** Only axis = 0 has been 
+    implemented.
+
     .. versionadded:: 2013.1
     """
     # {{{ find properties of result array
 
     shape = None
+    if axis != 0:
+        raise NotImplementedError("Axis != 0. "+
+                                  "To be implementedk when Array.setitems " +
+                                  "allows values with different stride".)
+
 
     for i_ary, ary in enumerate(arrays):
         queue = queue or ary.queue


### PR DESCRIPTION
As suggested in [this issue](https://github.com/inducer/pyopencl/issues/506#issuecomment-892134405), a warning was added both in the code and in the documentation.