### PR TITLE
Fix small sphinx docs rendering issue

### DIFF
--- a/doc/algorithm.rst
+++ b/doc/algorithm.rst
@@ -23,7 +23,7 @@ evaluate multi-stage expressions on one or several operands in a single pass.
 
         |std-enqueue-blurb|
 
-Here's a usage example::
+Here's a usage example:
 
 .. literalinclude:: ../examples/demo_elementwise.py
 


### PR DESCRIPTION
On the [parallel algorithms](https://documen.tician.de/pyopencl/algorithm.html) docs page, there is an RST directive inside a literal block, which I assume must be unintentional:

![image](https://user-images.githubusercontent.com/57452607/143322293-c7b548d8-7dbb-4a83-af84-b032eea0491c.png)

Removing one of the trailing colons in the preceding line should allow the directive to be interpreted correctly instead of placed into a literal block, though I did not confirm this before opening the PR.  