### PR TITLE
Make if_positive keep strides of then_ if known.

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -2864,7 +2864,7 @@ def if_positive(criterion, then_, else_, out=None, queue=None):
 
     if out is None:
 
-        if not then_.shape == ():
+        if then_.shape != ():
             out = empty_like(
                 then_, criterion.queue, allocator=criterion.allocator)
         else:

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -2865,13 +2865,13 @@ def if_positive(criterion, then_, else_, out=None, queue=None):
     if out is None:
 
         if not then_.shape == ():
-            out = empty_like( 
+            out = empty_like(
                 then_, criterion.queue, allocator=criterion.allocator)
-        else:   
+        else:
             # Use same strides as criterion
-            cr_byte_strides = np.array(criterion.strides,dtype=np.int64)
+            cr_byte_strides = np.array(criterion.strides, dtype=np.int64)
             cr_item_strides = cr_byte_strides // criterion.dtype.itemsize
-            out_strides = tuple(cr_item_strides*then_.dtype.itemsize)    
+            out_strides = tuple(cr_item_strides*then_.dtype.itemsize)
 
             out = Array(criterion.queue, criterion.shape, then_.dtype,
                         allocator=criterion.allocator,

--- a/pyopencl/version.py
+++ b/pyopencl/version.py
@@ -1,3 +1,3 @@
-VERSION = (2021, 2, 9)
+VERSION = (2021, 2, 10)
 VERSION_STATUS = ""
 VERSION_TEXT = ".".join(str(x) for x in VERSION) + VERSION_STATUS


### PR DESCRIPTION
The previous version of `if_positive` always returns a C-ordered array even if `then_` is not C-ordered. This breaks artificial viscosity in Mirgecom when an array context uses a Fortran style data layout. This change makes the output have the same strides as `then_` if the shape of `then_` is known, otherwise it defaults to use the same layout as `criterion`.