### PR TITLE
Add support for initial in reductions

### DIFF
--- a/doc/array.rst
+++ b/doc/array.rst
@@ -170,6 +170,8 @@ Reductions
 ^^^^^^^^^^
 
 .. autofunction:: sum
+.. autofunction:: all
+.. autofunction:: any
 .. autofunction:: dot
 .. autofunction:: vdot
 .. autofunction:: subset_dot


### PR DESCRIPTION
* Added support for `initial` in `sum`, `min` and `max`.
* Added `any` and `all` as toplevel functions in `cl.array`.