### PR TITLE
[cl.array] Prefer input arrays' constructor instead of cla.Array to instantiate the output

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -2622,6 +2622,9 @@ def concatenate(arrays, axis=0, queue=None, allocator=None):
     """
     .. versionadded:: 2013.1
     """
+    if not arrays:
+        raise ValueError("need at least one array to concatenate")
+
     # {{{ find properties of result array
 
     shape = None
@@ -2697,7 +2700,7 @@ def hstack(arrays, queue=None):
     from pyopencl.array import empty
 
     if len(arrays) == 0:
-        return empty(queue, (), dtype=np.float64)
+        raise ValueError("need at least one array to hstack")
 
     if queue is None:
         for ary in arrays:

--- a/pyopencl/reduction.py
+++ b/pyopencl/reduction.py
@@ -291,6 +291,7 @@ class ReductionKernel:
         SMALL_SEQ_COUNT = 4  # noqa
 
         from pyopencl.array import empty
+        empty = args[0].__class__ if args else empty
 
         stage_inf = self.stage_1_inf
 

--- a/pyopencl/version.py
+++ b/pyopencl/version.py
@@ -1,3 +1,3 @@
-VERSION = (2021, 2, 11)
+VERSION = (2021, 2, 12)
 VERSION_STATUS = ""
 VERSION_TEXT = ".".join(str(x) for x in VERSION) + VERSION_STATUS


### PR DESCRIPTION
- For the best viewing experience please switch to the commit-by-commit view.
- Version bump because of the following incoherence with numpy:
```python
>>> import numpy as np
>>> np.hstack([])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<__array_function__ internals>", line 180, in hstack
  File "/home/kgk2/projects/ceesd/miniforge3/envs/ceesd/lib/python3.8/site-packages/numpy/core/shape_base.py", line 345, in hstack
    return _nx.concatenate(arrs, 1)
  File "<__array_function__ internals>", line 180, in concatenate
ValueError: need at least one array to concatenate

need at least one array to concatenate
>>> import pyopencl.array as cla
>>> cla.hstack([])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kgk2/projects/ceesd/pyopencl/pyopencl/array.py", line 2700, in hstack
    return empty(queue, (), dtype=np.float64)
  File "/home/kgk2/projects/ceesd/pyopencl/pyopencl/array.py", line 580, in __init__
    self.base_data = cl.Buffer(
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. pyopencl._cl.Buffer(context: pyopencl._cl.Context, flags: int, size: int = 0, hostbuf: object = None)

Invoked with: None, 1, 8

__init__(): incompatible constructor arguments. The following argument types are supported:
    1. pyopencl._cl.Buffer(context: pyopencl._cl.Context, flags: int, size: int = 0, hostbuf: object = None)

Invoked with: None, 1, 8
```