### PR TITLE
Allow unsigned int for fancy indexing

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -1988,7 +1988,7 @@ class Array:
         """
 
         if isinstance(index, Array):
-            if index.dtype.kind != "i":
+            if index.dtype.kind not in ("i", "u"):
                 raise TypeError(
                         "fancy indexing is only allowed with integers")
             if len(index.shape) != 1:
@@ -2097,7 +2097,7 @@ class Array:
         wait_for = wait_for + self.events
 
         if isinstance(subscript, Array):
-            if subscript.dtype.kind != "i":
+            if subscript.dtype.kind not in ("i", "u"):
                 raise TypeError(
                         "fancy indexing is only allowed with integers")
             if len(subscript.shape) != 1:


### PR DESCRIPTION
Is there a reason this wasn't allowed?

Context: was trying to port `take` in `pytential` and an index was `uint8` (apparently because of [boxtree](https://github.com/inducer/boxtree/blob/bfc06e411679f512225a62e5fc74fb2489627016/boxtree/tree_build.py#L73)).