### PR TITLE
Switch from pybind11 to nanobind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0
                 build_py_project_in_conda_env
+
+                # Avoid linting local directory, where native module
+                # cannot be imported.
+                rm -Rf "$(get_proj_name)"
+
                 run_pylint "$(get_proj_name)" test/*.py
 
     mypy:
@@ -122,7 +127,7 @@ jobs:
 
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0
-                ./configure.py --cxxflags= --ldflags= --cl-libname=OpenCL
+                ./configure.py --cl-libname=OpenCL
                 build_py_project_in_conda_env
                 test_py_project
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+_skbuild
+
 .pydevproject
 .project
 .settings

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,31 +165,6 @@ Python 3 POCL (+GL and special functions):
     reports:
       junit: test/pytest.xml
 
-PyPy3 POCL:
-  script: |
-    export PY_EXE=pypy3
-    export PYOPENCL_TEST=portable:pthread
-    export NO_DOCTESTS=1
-
-    # On pypy, this seems to install old versions from the package index
-    # independently of whether newer ones are already present.
-    rm -f pyproject.toml
-    export EXTRA_INSTALL="pybind11 numpy mako"
-
-    curl -L -O https://tiker.net/ci-support-v0
-    . ci-support-v0
-    build_py_project_in_venv
-    test_py_project
-
-  tags:
-  - pypy
-  - pocl
-  except:
-  - tags
-  artifacts:
-    reports:
-      junit: test/pytest.xml
-
 Flake8:
   script: |
     curl -L -O https://tiker.net/ci-support-v0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.17...3.22)
+
+project(pyopencl)
+
+if (NOT SKBUILD)
+  message(FATAL_ERROR "This CMake file should be executed via scikit-build. "
+                      "Please run\n$ pip install .")
+endif()
+
+# {{{ Constrain FindPython to find the Python version used by scikit-build
+
+if (SKBUILD)
+  message(STATUS "Python_VERSION ${PYTHON_VERSION_STRING}")
+  message(STATUS "Python_EXECUTABLE ${PYTHON_EXECUTABLE}")
+  message(STATUS "Python_INCLUDE_DIR ${PYTHON_INCLUDE_DIR}")
+  message(STATUS "Python_LIBRARIES ${PYTHON_LIBRARY}")
+  set(Python_VERSION "${PYTHON_VERSION_STRING}")
+  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
+  set(Python_LIBRARIES "${PYTHON_LIBRARY}")
+endif()
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
+# }}}
+
+# {{{ Detect nanobind and import it
+
+execute_process(
+  COMMAND
+  "${PYTHON_EXECUTABLE}" -c "import nanobind; print(nanobind.cmake_dir())"
+  OUTPUT_VARIABLE _tmp_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
+  list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+
+# }}}
+
+link_directories(${PYOPENCL_CL_LIB_DIRS})
+
+find_package(nanobind CONFIG REQUIRED)
+find_package(NumPy REQUIRED)
+find_package(OpenCL REQUIRED)
+
+include_directories(${OpenCL_INCLUDE_DIR} ${NumPy_INCLUDE_DIRS})
+
+nanobind_add_module(
+  _cl
+  NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
+  src/wrap_constants.cpp
+  src/wrap_cl.cpp
+  src/wrap_cl_part_1.cpp
+  src/wrap_cl_part_2.cpp
+  src/wrap_mempool.cpp
+  src/bitlog.cpp
+)
+
+target_link_libraries(_cl PRIVATE ${OpenCL_LIBRARY})
+
+target_compile_definitions(_cl
+  PRIVATE
+  PYGPU_PACKAGE=pyopencl
+  PYGPU_PYOPENCL
+)
+
+if (PYOPENCL_PRETEND_CL_VERSION)
+  target_compile_definitions(
+    _cl PRIVATE PYOPENCL_PRETEND_CL_VERSION=${PYOPENCL_PRETEND_CL_VERSION})
+endif()
+
+if (PYOPENCL_ENABLE_GL)
+  target_compile_definitions(_cl PRIVATE HAVE_GL=1)
+endif()
+
+if (PYOPENCL_USE_SHIPPED_EXT)
+  target_compile_definitions(_cl PRIVATE PYOPENCL_USE_SHIPPED_EXT=1)
+endif()
+
+install(TARGETS _cl LIBRARY DESTINATION .)
+
+# vim: foldmethod=marker:sw=2

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -535,7 +535,7 @@ class Program:
     def _build_and_catch_errors(self, build_func, options_bytes, source=None):
         try:
             return build_func()
-        except _cl.RuntimeError as e:
+        except RuntimeError as e:
             msg = str(e)
             if options_bytes:
                 msg = msg + "\n(options: %s)" % options_bytes.decode("utf-8")
@@ -553,7 +553,7 @@ class Program:
             code = e.code
             routine = e.routine
 
-            err = _cl.RuntimeError(
+            err = RuntimeError(
                     _cl._ErrorRecord(
                         msg=msg,
                         code=code,
@@ -835,7 +835,7 @@ def _add_functionality():
         # }}}
 
         from pyopencl.invoker import generate_enqueue_and_set_args
-        enqueue, my_set_args = \
+        self._enqueue, self.set_args = \
                 generate_enqueue_and_set_args(
                         self.function_name,
                         len(arg_types), self.num_args,
@@ -843,20 +843,6 @@ def _add_functionality():
                         warn_about_arg_count_bug=warn_about_arg_count_bug,
                         work_around_arg_count_bug=work_around_arg_count_bug,
                         devs=self.context.devices)
-
-        # Make ourselves a kernel-specific class, so that we're able to override
-        # __call__. Inspired by https://stackoverflow.com/a/38541437
-        class KernelWithCustomEnqueue(type(self)):
-            __call__ = enqueue
-            set_args = my_set_args
-
-        try:
-            self.__class__ = KernelWithCustomEnqueue
-        except TypeError:
-            # __class__ assignment may not work in all cases, due to differing
-            # object layouts. Fall back to bouncing through kernel_call below.
-            self._enqueue = enqueue
-            self.set_args = my_set_args
 
     def kernel_get_work_group_info(self, param, device):
         cache_key = (param, device.int_ptr)

--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -379,7 +379,7 @@ if not cl._PYOPENCL_NO_CACHE:
     from pytools.py_codegen import PicklableModule
     invoker_cache: WriteOncePersistentDict[Any, Tuple[PicklableModule, str]] \
         = WriteOncePersistentDict(
-            "pyopencl-invoker-cache-v41",
+            "pyopencl-invoker-cache-v42-nano",
             key_builder=_NumpyTypesKeyBuilder(),
             in_mem_cache_size=0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,19 @@ requires = [
         "wheel>=0.34.2",
         "numpy;python_version >= '3.9' and platform_python_implementation == 'PyPy'",
         "oldest-supported-numpy;python_version < '3.9' or platform_python_implementation != 'PyPy'",
-        "pybind11>=2.5.0"
+        "scikit-build",
+        "cmake>=3.17",
+        "nanobind>=1.9.2",
+        "ninja; platform_system!='Windows'",
         ]
 build-backend = "setuptools.build_meta"
-
 
 [tool.cibuildwheel]
 test-command = "pytest {project}/test"
 test-extras = ["test"]
 
 [tool.cibuildwheel.linux]
-skip = ["pp37*", "cp36-*", "cp37-*", "*_i686"]
+skip = ["pp*", "cp36-*", "cp37-*", "*_i686"]
 test-command = ""
 before-all = [
     "yum install -y git openssl-devel ruby",
@@ -41,6 +43,10 @@ test-command = "pytest {project}/test/test_array.py" # same limitation as conda-
 archs = "x86_64 arm64"
 
 # https://github.com/conda-forge/pyopencl-feedstock/blob/6f3c5de59b18c9518abba3cb94f6ae92964553f8/recipe/meta.yaml#L62-L63
+
+[tool.cibuildwheel.macos.environment]
+# Needed for full C++17 support
+MACOSX_DEPLOYMENT_TARGET = "10.14"
 
 [tool.cibuildwheel.windows]
 skip = ["*-win32", "pp*", "cp36-*", "cp37-*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ multiline-quotes = """
 
 # enable-flake8-bugbear
 # enable-isort
+# disable-editable-pip-install
 
 [isort]
 line_length = 85

--- a/src/tools.hpp
+++ b/src/tools.hpp
@@ -28,7 +28,7 @@
 #define _ASDFDAFVVAFF_PYCUDA_HEADER_SEEN_TOOLS_HPP
 
 
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
 
 #include <numeric>
 #include <numpy/arrayobject.h>
@@ -51,9 +51,9 @@ namespace pyopencl
 
   inline void run_python_gc()
   {
-    namespace py = pybind11;
+    namespace py = nanobind;
 
-    py::module_::import("gc").attr("collect")();
+    py::module_::import_("gc").attr("collect")();
   }
 
 

--- a/src/wrap_cl.cpp
+++ b/src/wrap_cl.cpp
@@ -47,10 +47,10 @@ static bool import_numpy_helper()
   return true;
 }
 
-PYBIND11_MODULE(_cl, m)
+NB_MODULE(_cl, m)
 {
   if (!import_numpy_helper())
-    throw py::error_already_set();
+    throw py::python_error();
 
   pyopencl_expose_constants(m);
   pyopencl_expose_part_1(m);

--- a/src/wrap_constants.cpp
+++ b/src/wrap_constants.cpp
@@ -112,7 +112,7 @@ void pyopencl_expose_constants(py::module_ &m)
     DECLARE_EXC(RuntimeError, CLError.ptr());
 
     py::register_exception_translator(
-        [](std::exception_ptr p)
+        [](const std::exception_ptr &p, void * /* unused */)
         {
           try
           {
@@ -139,13 +139,13 @@ void pyopencl_expose_constants(py::module_ &m)
   {
     typedef error cls;
     py::class_<error> (m, "_ErrorRecord")
-      .def(py::init<const char *, cl_int, const char *>(),
+      .def(py::init<const std::string &, cl_int, const std::string &>(),
           py::arg("routine"),
           py::arg("code"),
           py::arg("msg"))
       .DEF_SIMPLE_METHOD(routine)
       .DEF_SIMPLE_METHOD(code)
-      .DEF_SIMPLE_METHOD(what)
+      .def("what", &cls::err_what)
       .DEF_SIMPLE_METHOD(is_out_of_memory)
       .def("_program", &cls::get_program)
       ;
@@ -1194,29 +1194,28 @@ void pyopencl_expose_constants(py::module_ &m)
   {
     typedef cl_name_version cls;
     py::class_<cls>(m, "NameVersion")
-      .def(py::init(
-            [](cl_version version, const char* name)
-            {
-              cl_name_version result;
-              result.version = version;
-              result.name[0] = '\0';
-              // https://stackoverflow.com/a/1258577
-              strncat(result.name, name, CL_NAME_VERSION_MAX_NAME_SIZE-1);
-              return result;
-            }),
+      .def("__init__",
+          [](cls *self, cl_version version, const std::string &name)
+          {
+            self->version = version;
+            self->name[0] = '\0';
+            // https://stackoverflow.com/a/1258577
+            strncat(self->name, name.c_str(), CL_NAME_VERSION_MAX_NAME_SIZE-1);
+          },
           py::arg("version")=0,
-          py::arg("name")=0)
+          py::arg("name")=0
+          )
 
-      .def_property("version",
+      .def_prop_rw("version",
           [](cls &t) { return t.version; },
           [](cls &t, cl_version val) { t.version = val; })
-      .def_property("name",
+      .def_prop_rw("name",
           [](cls &t) { return t.name; },
-          [](cls &t, const char *name)
+          [](cls &t, const std::string &name)
           {
               t.name[0] = '\0';
               // https://stackoverflow.com/a/1258577
-              strncat(t.name, name, CL_NAME_VERSION_MAX_NAME_SIZE-1);
+              strncat(t.name, name.c_str(), CL_NAME_VERSION_MAX_NAME_SIZE-1);
           })
       ;
   }
@@ -1229,33 +1228,38 @@ void pyopencl_expose_constants(py::module_ &m)
   {
     typedef cl_device_topology_amd cls;
     py::class_<cls>(m, "DeviceTopologyAmd")
-      .def(py::init(
-            [](cl_char bus, cl_char device, cl_char function)
-            {
-              cl_device_topology_amd result;
-              result.pcie.type = CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD;
-              result.pcie.bus = bus;
-              result.pcie.device = device;
-              result.pcie.function = function;
-              return result;
-            }),
+      .def("__init__",
+
+          // FIXME: Nanobind thinks of 'char' as "short string", not small integer.
+          // The detour via cl_int may lose data on assignment.
+          // [](cl_char bus, cl_char device, cl_char function)
+          [](cls *self, cl_int bus, cl_int device, cl_int function)
+          {
+            self->pcie.type = CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD;
+            self->pcie.bus = (cl_char) bus;
+            self->pcie.device = (cl_char) device;
+            self->pcie.function = (cl_char) function;
+          },
           py::arg("bus")=0,
           py::arg("device")=0,
           py::arg("function")=0)
 
-      .def_property("type",
+      .def_prop_rw("type",
           [](cls &t) { return t.pcie.type; },
           [](cls &t, cl_uint val) { t.pcie.type = val; })
 
-      .def_property("bus",
+      .def_prop_rw("bus",
           [](cls &t) { return t.pcie.bus; },
-          [](cls &t, cl_char val) { t.pcie.bus = val; })
-      .def_property("device",
+          // FIXME: Revert to cl_char when possible
+          [](cls &t, cl_int val) { t.pcie.bus = (cl_char) val; })
+      .def_prop_rw("device",
           [](cls &t) { return t.pcie.device; },
-          [](cls &t, cl_char val) { t.pcie.device = val; })
-      .def_property("function",
+          // FIXME: Revert to cl_char when possible
+          [](cls &t, cl_int val) { t.pcie.device = (cl_char) val; })
+      .def_prop_rw("function",
           [](cls &t) { return t.pcie.function; },
-          [](cls &t, cl_char val) { t.pcie.function = val; })
+          // FIXME: Revert to cl_char when possible
+          [](cls &t, cl_int val) { t.pcie.function = (cl_char) val; })
       ;
   }
 #endif


### PR DESCRIPTION
Surprisingly, this is mostly working now. :)

To do/Needs:
- [x] ~~Pass location of numpy headers to CMake~~ (found via CMake now)
- [x] ~~Pass OpenCL config info to CMake~~ (found via CMake now)
- [x] Actually fix the wrapper :slightly_smiling_face: 
    - [x] ` pycl test_wrapper.py 'test_mempool(cl._csc)' ` crashes
    - [x] `PYOPENCL_TEST=port python test_array.py "test_mem_pool_with_arrays(cl._csc)" ` crashes
    - [x] Doesn't make it through the meshmode test suite
- [x] https://github.com/wjakob/nanobind/pull/38
- [x] ~~https://github.com/wjakob/nanobind/pull/23~~
- [x] ~~https://github.com/wjakob/nanobind/pull/24~~
- [x] ~~See if the `_enqueue` trampoline can be avoided~~ (doesn't matter for loopy enqueues, that goes straight to `enqueue_nd_range_kernel`)
- [x] ~~https://github.com/wjakob/nanobind/pull/71~~
- [x] Expose SVM-as-buffer
- [x] Investigate reference leaks after tests: they've disappeared.
- [x] ~~Wait for nanobind 2, for `for_setter`.~~
- [x] Pass CI
- [x] Check loopy CI. Currently, it requires weak references to `cl.Context`, which nanobind doesn't currently allow. (Edit: [Now does allow.](https://nanobind.readthedocs.io/en/latest/classes.html#weak-references))
- [x] ~~Work around https://github.com/wjakob/nanobind/pull/72~~ (This seems to have been resolved in the meantime.)