### PR TITLE
Warn/error if queue used after context manager exit

### DIFF
--- a/doc/runtime_queue.rst
+++ b/doc/runtime_queue.rst
@@ -32,7 +32,7 @@ Command Queue
             enqueue_stuff(queue, ...)
 
     :meth:`finish` is automatically called at the end of the ``with``-delimited
-    context.
+    context, and further operations on the queue are considered an error.
 
     .. versionadded:: 2013.1
 
@@ -41,6 +41,13 @@ Command Queue
     .. versionchanged:: 2018.2
 
         Added the sequence-of-properties interface for OpenCL 2.
+
+    .. versionchanged:: 2022.1.4
+
+        Use of a command queue after its context manager completes
+        is now considered an error. :mod:`pyopencl` will warn about this
+        for a transitionary period and will start raising an exception
+        in 2023.
 
     .. attribute:: info
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -261,6 +261,10 @@ class CompilerWarning(UserWarning):
     pass
 
 
+class CommandQueueUsedAfterExit(UserWarning):
+    pass
+
+
 def compiler_output(text):
     import os
     from warnings import warn
@@ -706,6 +710,7 @@ def _add_functionality():
 
     def command_queue_exit(self, exc_type, exc_val, exc_tb):
         self.finish()
+        self._finalize()
 
     def command_queue_get_cl_version(self):
         return self.device._get_cl_version()

--- a/src/wrap_cl_part_1.cpp
+++ b/src/wrap_cl_part_1.cpp
@@ -120,6 +120,7 @@ void pyopencl_expose_part_1(py::module &m)
         py::arg("context"),
         py::arg("device").none(true)=py::none(),
         py::arg("properties")=py::cast(0))
+      .def("_finalize", &cls::finalize)
       .DEF_SIMPLE_METHOD(get_info)
 #if PYOPENCL_CL_VERSION < 0x1010
       .DEF_SIMPLE_METHOD(set_property)

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -1247,6 +1247,15 @@ def test_empty_ndrange(ctx_factory, empty_shape):
     prg.add_two(queue, a.shape, None, a.data, allow_empty_ndrange=True)
 
 
+def test_command_queue_context_manager(ctx_factory):
+    ctx = ctx_factory()
+    with cl.CommandQueue(ctx) as queue:
+        q = queue
+
+    with pytest.warns(cl.CommandQueueUsedAfterExit):
+        q.finish()
+
+
 if __name__ == "__main__":
     # make sure that import failures get reported, instead of skipping the tests.
     import pyopencl  # noqa


### PR DESCRIPTION
Prompted by this discussion: https://github.com/inducer/sumpy/pull/117#discussion_r868681678