### PR TITLE
Fix pocl version parsing

### DIFF
--- a/pyopencl/characterize/__init__.py
+++ b/pyopencl/characterize/__init__.py
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 import pyopencl as cl
 from pytools import memoize
+from typing import Optional, Tuple
 
 
 class CLCharacterizationWarning(UserWarning):
@@ -318,22 +319,23 @@ def get_simd_group_size(dev, type_size):
     return None
 
 
-def get_pocl_version(platform, fallback_value=None):
+def get_pocl_version(
+        platform: cl.Platform,
+        fallback_value: Optional[Tuple[int, int]] = None
+        ) -> Optional[Tuple[int, int]]:
     if platform.name != "Portable Computing Language":
         return None
 
     import re
     version = platform.version
-    ver_match = re.match(r"^OpenCL [0-9.]+ pocl ([0-9]+)\.([0-9]+)", version)
+    ver_match = re.match(
+            r"^OpenCL [0-9.]+ [Pp]o[Cc][Ll] ([0-9]+)\.([0-9]+)", version)
 
     if ver_match is None:
         msg = f"pocl version number did not have expected format: '{version}'"
-        if fallback_value is not None:
-            from warnings import warn
-            warn(msg)
-            return fallback_value
-        else:
-            raise ValueError(msg)
+        from warnings import warn
+        warn(msg)
+        return fallback_value
     else:
         return (int(ver_match.group(1)), int(ver_match.group(2)))
 

--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -313,8 +313,8 @@ def _get_max_parameter_size(dev):
     from pyopencl.characterize import get_pocl_version
 
     dev_limit = dev.max_parameter_size
-
-    if get_pocl_version(dev.platform) is not None:
+    pocl_version = get_pocl_version(dev.platform, fallback_value=(1, 8))
+    if pocl_version is not None and pocl_version < (3, 0):
         # Current pocl versions (as of 04/2022) have an incorrect parameter
         # size limit of 1024; see e.g. https://github.com/pocl/pocl/pull/1046
         if dev_limit == 1024:


### PR DESCRIPTION
Without this fix, PyOpenCL dies on pocl versions 3.0pre and newer with
```
Traceback (most recent call last):                                                                                                                                                                                                              
  File "/home/andreas/src/pyopencl/test/test_algorithm.py", line 52, in test_elwise_kernel                                                                                                                                                      
    a_gpu = clrand(queue, (50,), np.float32)                                                                                                                                                                                                    
  File "/home/andreas/src/pyopencl/pyopencl/clrandom.py", line 767, in rand                                                                                                                                                                     
    gen.fill_uniform(result, a=a, b=b)                                                                                                                                                                                                          
  File "/home/andreas/src/pyopencl/pyopencl/clrandom.py", line 681, in fill_uniform                                                                                                                                                             
    return self._fill("uniform", ary,                                                                                                                                                                                                           
  File "/home/andreas/src/pyopencl/pyopencl/clrandom.py", line 658, in _fill                                                                                                                                                                    
    self.get_gen_kernel(ary.dtype, distribution)                                                                                                                                                                                                
  File "/home/andreas/src/pytools/pytools/__init__.py", line 755, in wrapper                                                                                                                                                                    
    result = function(obj, *args, **kwargs)                                                                                                                                                                                                     
  File "/home/andreas/src/pyopencl/pyopencl/clrandom.py", line 640, in get_gen_kernel                                                                                                                                                           
    knl = getattr(prg, kernel_name)                                                                                                                                                                                                             
  File "/home/andreas/src/pyopencl/pyopencl/__init__.py", line 461, in __getattr__                                                                                                                                                              
    knl = Kernel(self, attr)                                                                                                                                                                                                                    
  File "/home/andreas/src/pyopencl/pyopencl/__init__.py", line 817, in kernel_init                                                                                                                                                              
    self._setup(prg)                                                                                                                                                                                                                            
  File "/home/andreas/src/pyopencl/pyopencl/__init__.py", line 823, in kernel__setup                                                                                                                                                            
    self._enqueue, self._set_args = generate_enqueue_and_set_args(                                                                                                                                                                              
  File "/home/andreas/src/pyopencl/pyopencl/invoker.py", line 384, in generate_enqueue_and_set_args                                                                                                                                             
    _check_arg_size(function_name, num_cl_args, arg_types, devs)                                                                                                                                                                                
  File "/home/andreas/src/pyopencl/pyopencl/invoker.py", line 336, in _check_arg_size                                                                                                                                                           
    dev_limit = _get_max_parameter_size(dev)                                                                                                                                                                                                    
  File "/home/andreas/src/pyopencl/pyopencl/invoker.py", line 317, in _get_max_parameter_size                                                                                                                                                   
    if get_pocl_version(dev.platform) is not None:                                                                                                                                                                                              
  File "/home/andreas/src/pyopencl/pyopencl/characterize/__init__.py", line 336, in get_pocl_version                                                                                                                                            
    raise ValueError(msg)                                                                                                                                                                                                                       
ValueError: pocl version number did not have expected format: 'OpenCL 3.0 PoCL 1.9-pre tags/v3.0-RC1-0-g72b4fe4  Linux, Release, RELOC, SPIR, LLVM 14.0.3, SLEEF, POCL_DEBUG'   
```