### PR TITLE
Update inforamation about provided wheels versions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -63,6 +63,7 @@ authors:
   given-names: "Alex"
 - family-names: "Bokota"
   given-names: "Grzegorz"
+  orcid: 'https://orcid.org/0000-0002-5470-1676'
 
 title: "PyOpenCL"
 version: 2022.1.3

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -136,8 +136,11 @@ using registry keys are automatically available.
 Installing from PyPI wheels
 ---------------------------
 
-PyOpenCL distributes python 3.6-3.10 for macOS, Windows, GLIBC base Linux and musl base Linux.
+PyOpenCL distributes wheels for Python 3.6-3.10 for macOS, Windows, GLIBC base Linux and musl base Linux.
 For GLIBC base linux minimum version of GLIBC is 2.17. 
+There are also distributted wheels for PyPy 3.7-3.9 but only for GLIBC based linux 
+
+For all systems there are 64 bit wheels available. 32 bit wheels are available for linux only.
 
 Wheels for linux are build using `ocl-icd`. Wheels for Windows and MacOS are build using 
 OpenCL-ICD-Loader from KhronosGroup

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -133,17 +133,21 @@ and it is packaged so that the OpenCL drivers that are registered in the OS
 using registry keys are automatically available.
 
 
-Installing from PyPI with Linux wheels
---------------------------------------
+Installing from PyPI wheels
+---------------------------
 
-PyOpenCL distributes ``manylinux1`` wheels in PyPI. These wheels are compatible with
-GLIBC>=2.5 based distributions.
+PyOpenCL distributes python 3.6-3.10 for macOS, Windows, GLIBC base Linux and musl base Linux.
+For GLIBC base linux minimum version of GLIBC is 2.17. 
 
-On Linux, type::
+Wheels for linux are build using `ocl-icd`. Wheels for Windows and MacOS are build using 
+OpenCL-ICD-Loader from KhronosGroup
+
+
+To install type::
 
     pip install pyopencl
 
-The wheels comes with OCL-ICD bundled and configured to use any OpenCL implementation
+On Linux the wheels comes with OCL-ICD bundled and configured to use any OpenCL implementation
 supporting ICD interface installed in :file:`/etc/OpenCL/vendors`
 
 You can also install the following CPU based OpenCL implementation using pip shipped as binary

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -136,16 +136,16 @@ using registry keys are automatically available.
 Installing from PyPI wheels
 ---------------------------
 
-PyOpenCL distributes wheels for most popular systems and versions.
-To check available versions please visit `PyPI page for PyOpenCL <https://pypi.org/project/pyopencl/>`_
+PyOpenCL distributes wheels for most popular OSs and Python versions.
+To check available versions please visit `PyPI page for PyOpenCL <https://pypi.org/project/pyopencl/>`__.
 
 
-On Linux the wheels comes with OCL-ICD bundled and configured to use any OpenCL implementation
-supporting ICD interface installed in :file:`/etc/OpenCL/vendors`.
-Wheels for Windows and MacOS are build using 
-OpenCL-ICD-Loader from KhronosGroup
+On Linux, the wheels come with `OCL-ICD <https://github.com/OCL-dev/ocl-icd>`__ bundled and
+configured to use any OpenCL implementation supporting the ICD interface and listed
+in :file:`/etc/OpenCL/vendors`.
+Wheels for Windows and MacOS are built using the ICD Loader from the Khronos Group.
 
-To install type::
+To install, type::
 
     pip install pyopencl
 

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -136,22 +136,19 @@ using registry keys are automatically available.
 Installing from PyPI wheels
 ---------------------------
 
-PyOpenCL distributes wheels for Python 3.6-3.10 for macOS, Windows, GLIBC base Linux and musl base Linux.
-For GLIBC base linux minimum version of GLIBC is 2.17. 
-There are also distributted wheels for PyPy 3.7-3.9 but only for GLIBC based linux 
+PyOpenCL distributes wheels for most popular systems and versions.
+To check available versions please visit `PyPI page for PyOpenCL <https://pypi.org/project/pyopencl/>`_
 
-For all systems there are 64 bit wheels available. 32 bit wheels are available for linux only.
 
-Wheels for linux are build using `ocl-icd`. Wheels for Windows and MacOS are build using 
+On Linux the wheels comes with OCL-ICD bundled and configured to use any OpenCL implementation
+supporting ICD interface installed in :file:`/etc/OpenCL/vendors`.
+Wheels for Windows and MacOS are build using 
 OpenCL-ICD-Loader from KhronosGroup
-
 
 To install type::
 
     pip install pyopencl
 
-On Linux the wheels comes with OCL-ICD bundled and configured to use any OpenCL implementation
-supporting ICD interface installed in :file:`/etc/OpenCL/vendors`
 
 You can also install the following CPU based OpenCL implementation using pip shipped as binary
 wheels. Note that pyopencl has to be installed using a wheel for pyopencl to recognize these


### PR DESCRIPTION
This PR is a follow-up for #559 and adds information about available wheels in the documentation.  

It may be a little too detailed?