### PR TITLE
fix compilation error with pybind 2.10

### DIFF
--- a/src/wrap_constants.cpp
+++ b/src/wrap_constants.cpp
@@ -106,7 +106,7 @@ void pyopencl_expose_constants(py::module &m)
 #define DECLARE_EXC(NAME, BASE) \
   static py::exception<pyopencl::error> CL##NAME(m, #NAME, BASE);
 
-    DECLARE_EXC(Error, NULL);
+    DECLARE_EXC(Error, nullptr);
     DECLARE_EXC(MemoryError, CLError.ptr());
     DECLARE_EXC(LogicError, CLError.ptr());
     DECLARE_EXC(RuntimeError, CLError.ptr());


### PR DESCRIPTION
Fixes the compilation error in CI due to (I suspect) https://github.com/pybind/pybind11/pull/4008 