### PR TITLE
SVM Memory Pool

### DIFF
--- a/doc/runtime_memory.rst
+++ b/doc/runtime_memory.rst
@@ -281,6 +281,8 @@ Transfers
 
 .. autofunction:: enqueue_copy(queue, dest, src, **kwargs)
 
+.. autofunction:: enqueue_fill(queue, dest, src, **kwargs)
+
 Mapping Memory into Host Address Space
 --------------------------------------
 

--- a/examples/demo_array_svm.py
+++ b/examples/demo_array_svm.py
@@ -1,36 +1,24 @@
 import pyopencl as cl
 import pyopencl.array as cl_array
+from pyopencl.tools import SVMAllocator
 import numpy as np
 import numpy.linalg as la
 
-n = 5000000
+n = 500000
 a = np.random.rand(n).astype(np.float32)
 b = np.random.rand(n).astype(np.float32)
-
-
-class SVMAllocator:
-    def __init__(self, ctx, flags, alignment):
-        self._context = ctx
-        self._flags = flags
-        self._alignment = alignment
-
-    def __call__(self, nbytes):
-        return cl.SVM(cl.svm_empty(
-                ctx, self._flags, (nbytes,), np.int8, "C", self._alignment))
 
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
 
-alloc = SVMAllocator(ctx,
-        cl.svm_mem_flags.READ_WRITE | cl.svm_mem_flags.SVM_FINE_GRAIN_BUFFER,
-        0)
+alloc = SVMAllocator(ctx, cl.svm_mem_flags.READ_WRITE, queue=queue)
 
 a_dev = cl_array.to_device(queue, a, allocator=alloc)
-print("A_DEV", a_dev.data.mem.nbytes, a_dev.data.mem.__array_interface__)
+print("A_DEV", a_dev.data)
 b_dev = cl_array.to_device(queue, b, allocator=alloc)
 dest_dev = cl_array.empty_like(a_dev)
-print("DEST", dest_dev.data.mem.__array_interface__)
+print("DEST", dest_dev.data)
 
 prg = cl.Program(ctx, """
     __kernel void sum(__global const float *a,
@@ -47,6 +35,7 @@ knl(queue, a.shape, None, a_dev.data, b_dev.data, dest_dev.data)
 # PROBLEM: numpy frees the temporary out of (a_dev+b_dev) before
 # we're done with it
 diff = dest_dev - (a_dev+b_dev)
+
 if 0:
     diff = diff.get()
     np.set_printoptions(linewidth=400)

--- a/examples/demo_array_svm.py
+++ b/examples/demo_array_svm.py
@@ -1,0 +1,57 @@
+import pyopencl as cl
+import pyopencl.array as cl_array
+import numpy as np
+import numpy.linalg as la
+
+n = 5000000
+a = np.random.rand(n).astype(np.float32)
+b = np.random.rand(n).astype(np.float32)
+
+
+class SVMAllocator:
+    def __init__(self, ctx, flags, alignment):
+        self._context = ctx
+        self._flags = flags
+        self._alignment = alignment
+
+    def __call__(self, nbytes):
+        return cl.SVM(cl.svm_empty(
+                ctx, self._flags, (nbytes,), np.int8, "C", self._alignment))
+
+
+ctx = cl.create_some_context()
+queue = cl.CommandQueue(ctx)
+
+alloc = SVMAllocator(ctx,
+        cl.svm_mem_flags.READ_WRITE | cl.svm_mem_flags.SVM_FINE_GRAIN_BUFFER,
+        0)
+
+a_dev = cl_array.to_device(queue, a, allocator=alloc)
+print("A_DEV", a_dev.data.mem.nbytes, a_dev.data.mem.__array_interface__)
+b_dev = cl_array.to_device(queue, b, allocator=alloc)
+dest_dev = cl_array.empty_like(a_dev)
+print("DEST", dest_dev.data.mem.__array_interface__)
+
+prg = cl.Program(ctx, """
+    __kernel void sum(__global const float *a,
+    __global const float *b, __global float *c)
+    {
+      int gid = get_global_id(0);
+      c[gid] = a[gid] + b[gid];
+    }
+    """).build()
+
+knl = prg.sum  # Use this Kernel object for repeated calls
+knl(queue, a.shape, None, a_dev.data, b_dev.data, dest_dev.data)
+
+# PROBLEM: numpy frees the temporary out of (a_dev+b_dev) before
+# we're done with it
+diff = dest_dev - (a_dev+b_dev)
+if 0:
+    diff = diff.get()
+    np.set_printoptions(linewidth=400)
+    print(dest_dev)
+    print((a_dev+b_dev).get())
+    print(diff)
+    print(la.norm(diff))
+    print("A_DEV", a_dev.data.mem.__array_interface__)

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1779,6 +1779,9 @@ def enqueue_copy(queue, dest, src, **kwargs):
             src = SVM(src)
 
         is_blocking = kwargs.pop("is_blocking", True)
+        assert kwargs.pop("src_offset", 0) == 0
+        assert kwargs.pop("dest_offset", 0) == 0
+        assert "byte_count" not in kwargs or kwargs.pop("byte_count") == src._size()
         return _cl._enqueue_svm_memcpy(queue, is_blocking, dest, src, **kwargs)
 
     else:

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -200,11 +200,9 @@ if get_cl_header_version() >= (1, 2):
 
 if get_cl_header_version() >= (2, 0):
     from pyopencl._cl import (  # noqa
-        SVMAllocation,
+        SVMPointer,
         SVM,
-
-        # FIXME
-        #enqueue_svm_migratemem,
+        SVMAllocation,
         )
 
 if _cl.have_gl():
@@ -1144,25 +1142,19 @@ def _add_functionality():
             """
 
     if get_cl_header_version() >= (2, 0):
-        svmallocation_old_init = SVMAllocation.__init__
+        class _ArrayInterfaceSVMAllocation(SVMAllocation):
+            def __init__(self, ctx, size, alignment, flags, _interface=None,
+                    queue=None):
+                """
+                :arg ctx: a :class:`Context`
+                :arg flags: some of :class:`svm_mem_flags`.
+                """
+                super().__init__(ctx, size, alignment, flags, queue)
 
-    def svmallocation_init(self, ctx, size, alignment, flags, _interface=None,
-            queue=None):
-        """
-        :arg ctx: a :class:`Context`
-        :arg flags: some of :class:`svm_mem_flags`.
-        """
-        svmallocation_old_init(self, ctx, size, alignment, flags, queue)
-
-        # mem_flags.READ_ONLY applies to kernels, not the host
-        read_write = True
-        _interface["data"] = (
-                int(self._ptr_as_int()), not read_write)
-
-        self.__array_interface__ = _interface
-
-    if get_cl_header_version() >= (2, 0):
-        SVMAllocation.__init__ = svmallocation_init
+                # mem_flags.READ_ONLY applies to kernels, not the host
+                read_write = True
+                _interface["data"] = (
+                        int(self._ptr_as_int()), not read_write)
 
     # }}}
 
@@ -1773,15 +1765,14 @@ def enqueue_copy(queue, dest, src, **kwargs):
         else:
             raise ValueError("invalid dest mem object type")
 
-    elif get_cl_header_version() >= (2, 0) and isinstance(dest, SVM):
+    elif get_cl_header_version() >= (2, 0) and isinstance(dest, SVMPointer):
         # to SVM
-        if not isinstance(src, SVM):
+        if not isinstance(src, SVMPointer):
             src = SVM(src)
 
         is_blocking = kwargs.pop("is_blocking", True)
         assert kwargs.pop("src_offset", 0) == 0
         assert kwargs.pop("dest_offset", 0) == 0
-        assert "byte_count" not in kwargs or kwargs.pop("byte_count") == src._size()
         return _cl._enqueue_svm_memcpy(queue, is_blocking, dest, src, **kwargs)
 
     else:
@@ -1807,7 +1798,7 @@ def enqueue_copy(queue, dest, src, **kwargs):
                         queue, src, origin, region, dest, **kwargs)
             else:
                 raise ValueError("invalid src mem object type")
-        elif isinstance(src, SVM):
+        elif isinstance(src, SVMPointer):
             # from svm
             # dest is not a SVM instance, otherwise we'd be in the branch above
             is_blocking = kwargs.pop("is_blocking", True)
@@ -1822,14 +1813,14 @@ def enqueue_copy(queue, dest, src, **kwargs):
 
 # {{{ enqueue_fill
 
-def enqueue_fill(queue: CommandQueue, dest: Union[MemoryObjectHolder, SVM],
+def enqueue_fill(queue: CommandQueue, dest: Union[MemoryObjectHolder, SVMPointer],
         pattern: Any, size: int, *, offset: int = 0, wait_for=None) -> Event:
     """
     .. versionadded:: 2022.2
     """
     if isinstance(dest, MemoryObjectHolder):
         return enqueue_fill_buffer(queue, dest, pattern, offset, size, wait_for)
-    elif isinstance(dest, SVM):
+    elif isinstance(dest, SVMPointer):
         if offset:
             raise NotImplementedError("enqueue_fill with SVM does not yet support "
                     "offsets")
@@ -1961,7 +1952,7 @@ def enqueue_fill_buffer(queue, mem, pattern, offset, size, wait_for=None):
 def enqueue_svm_memfill(queue, dest, pattern, byte_count=None, wait_for=None):
     """Fill shared virtual memory with a pattern.
 
-    :arg dest: a Python buffer object, optionally wrapped in an :class:`SVM` object
+    :arg dest: a Python buffer object, or any implementation of :class:`SVMPointer`.
     :arg pattern: a Python buffer object (e.g. a :class:`numpy.ndarray` with the
         fill pattern to be used.
     :arg byte_count: The size of the memory to be fill. Defaults to the
@@ -1972,8 +1963,8 @@ def enqueue_svm_memfill(queue, dest, pattern, byte_count=None, wait_for=None):
     .. versionadded:: 2016.2
     """
 
-    if not isinstance(dest, SVM):
-        dest = SVM(dest)
+    if not isinstance(dest, SVMPointer):
+        dest = SVMPointer(dest)
 
     return _cl._enqueue_svm_memfill(
             queue, dest, pattern, byte_count=None, wait_for=None)
@@ -1982,7 +1973,7 @@ def enqueue_svm_memfill(queue, dest, pattern, byte_count=None, wait_for=None):
 def enqueue_svm_migratemem(queue, svms, flags, wait_for=None):
     """
     :arg svms: a collection of Python buffer objects (e.g. :mod:`numpy`
-        arrays), optionally wrapped in :class:`SVM` objects.
+        arrays), or any implementation of :class:`SVMPointer`.
     :arg flags: a combination of :class:`mem_migration_flags`
 
     |std-enqueue-blurb|
@@ -2068,7 +2059,8 @@ def svm_empty(ctx, flags, shape, dtype, order="C", alignment=None, queue=None):
     if alignment is None:
         alignment = itemsize
 
-    svm_alloc = SVMAllocation(ctx, nbytes, alignment, flags, _interface=interface,
+    svm_alloc = _ArrayInterfaceSVMAllocation(
+            ctx, nbytes, alignment, flags, _interface=interface,
             queue=queue)
     return np.asarray(svm_alloc)
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1146,12 +1146,13 @@ def _add_functionality():
     if get_cl_header_version() >= (2, 0):
         svmallocation_old_init = SVMAllocation.__init__
 
-    def svmallocation_init(self, ctx, size, alignment, flags, _interface=None):
+    def svmallocation_init(self, ctx, size, alignment, flags, _interface=None,
+            queue=None):
         """
         :arg ctx: a :class:`Context`
         :arg flags: some of :class:`svm_mem_flags`.
         """
-        svmallocation_old_init(self, ctx, size, alignment, flags)
+        svmallocation_old_init(self, ctx, size, alignment, flags, queue)
 
         # mem_flags.READ_ONLY applies to kernels, not the host
         read_write = True
@@ -1996,7 +1997,7 @@ def enqueue_svm_migratemem(queue, svms, flags, wait_for=None):
             wait_for)
 
 
-def svm_empty(ctx, flags, shape, dtype, order="C", alignment=None):
+def svm_empty(ctx, flags, shape, dtype, order="C", alignment=None, queue=None):
     """Allocate an empty :class:`numpy.ndarray` of the given *shape*, *dtype*
     and *order*. (See :func:`numpy.empty` for the meaning of these arguments.)
     The array will be allocated in shared virtual memory belonging
@@ -2014,6 +2015,10 @@ def svm_empty(ctx, flags, shape, dtype, order="C", alignment=None):
     will likely want to wrap the returned array in an :class:`SVM` tag.
 
     .. versionadded:: 2016.2
+
+    .. versionchanged:: 2022.2
+
+        *queue* argument added.
     """
 
     dtype = np.dtype(dtype)
@@ -2060,7 +2065,8 @@ def svm_empty(ctx, flags, shape, dtype, order="C", alignment=None):
     if alignment is None:
         alignment = itemsize
 
-    svm_alloc = SVMAllocation(ctx, nbytes, alignment, flags, _interface=interface)
+    svm_alloc = SVMAllocation(ctx, nbytes, alignment, flags, _interface=interface,
+            queue=queue)
     return np.asarray(svm_alloc)
 
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 from sys import intern
 from warnings import warn
+from typing import Union, Any
 
 from pyopencl.version import VERSION, VERSION_STATUS, VERSION_TEXT  # noqa
 
@@ -1811,6 +1812,26 @@ def enqueue_copy(queue, dest, src, **kwargs):
         else:
             # assume from-host
             raise TypeError("enqueue_copy cannot perform host-to-host transfers")
+
+# }}}
+
+
+# {{{ enqueue_fill
+
+def enqueue_fill(queue: CommandQueue, dest: Union[MemoryObjectHolder, SVM],
+        pattern: Any, size: int, *, offset: int = 0, wait_for=None) -> Event:
+    """
+    .. versionadded:: 2022.2
+    """
+    if isinstance(dest, MemoryObjectHolder):
+        return enqueue_fill_buffer(queue, dest, pattern, offset, size, wait_for)
+    elif isinstance(dest, SVM):
+        if offset:
+            raise NotImplementedError("enqueue_fill with SVM does not yet support "
+                    "offsets")
+        return enqueue_svm_memfill(queue, dest, pattern, size, wait_for)
+    else:
+        raise TypeError(f"enqueue_fill does not know how to fill '{type(dest)}'")
 
 # }}}
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -21,6 +21,7 @@ THE SOFTWARE.
 """
 
 from sys import intern
+from warnings import warn
 
 from pyopencl.version import VERSION, VERSION_STATUS, VERSION_TEXT  # noqa
 
@@ -43,7 +44,6 @@ except ImportError:
     import os
     from os.path import dirname, join, realpath
     if realpath(join(os.getcwd(), "pyopencl")) == realpath(dirname(__file__)):
-        from warnings import warn
         warn("It looks like you are importing PyOpenCL from "
                 "its source directory. This likely won't work.")
     raise
@@ -267,7 +267,6 @@ class CommandQueueUsedAfterExit(UserWarning):
 
 def compiler_output(text):
     import os
-    from warnings import warn
     if int(os.environ.get("PYOPENCL_COMPILER_OUTPUT", "0")):
         warn(text, CompilerWarning)
     else:
@@ -389,7 +388,6 @@ def enable_debugging(platform_or_context):
         import os
         os.environ["CPU_MAX_COMPUTE_UNITS"] = "1"
     else:
-        from warnings import warn
         warn("do not know how to enable debugging on '%s'"
                 % platform.name)
 
@@ -428,7 +426,6 @@ class Program:
             return self._prg
         else:
             # "no program" can only happen in from-source case.
-            from warnings import warn
             warn("Pre-build attribute access defeats compiler caching.",
                     stacklevel=3)
 
@@ -662,7 +659,6 @@ def _add_functionality():
         return ("v1", self.vendor, self.vendor_id, self.name, self.version)
 
     def device_persistent_unique_id(self):
-        from warnings import warn
         warn("Device.persistent_unique_id is deprecated. "
                 "Use Device.hashable_model_and_version_identifier instead.",
                 DeprecationWarning, stacklevel=2)
@@ -684,7 +680,6 @@ def _add_functionality():
 
     def context_init(self, devices, properties, dev_type, cache_dir=None):
         if cache_dir is not None:
-            from warnings import warn
             warn("The 'cache_dir' argument to the Context constructor "
                 "is deprecated and no longer has an effect. "
                 "It was removed because it only applied to the wrapper "
@@ -970,7 +965,6 @@ def _add_functionality():
 
         if hostbuf is not None and not \
                 (flags & (mem_flags.USE_HOST_PTR | mem_flags.COPY_HOST_PTR)):
-            from warnings import warn
             warn("'hostbuf' was passed, but no memory flags to make use of it.")
 
         if hostbuf is None and pitches is not None:
@@ -1043,7 +1037,6 @@ def _add_functionality():
 
     class _ImageInfoGetter:
         def __init__(self, event):
-            from warnings import warn
             warn("Image.image.attr is deprecated and will go away in 2021. "
                     "Use Image.attr directly, instead.")
 
@@ -1927,7 +1920,6 @@ def enqueue_barrier(queue, wait_for=None):
 
 def enqueue_fill_buffer(queue, mem, pattern, offset, size, wait_for=None):
     if not (queue._get_cl_version() >= (1, 2) and get_cl_header_version() >= (1, 2)):
-        from warnings import warn
         warn("The context for this queue does not declare OpenCL 1.2 support, so "
                 "the next thing you might see is a crash")
 

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -720,9 +720,14 @@ class Array:
                     stacklevel=2)
 
         if self.size:
-            event1 = cl.enqueue_copy(queue or self.queue, self.base_data, ary,
-                    device_offset=self.offset,
-                    is_blocking=not async_)
+            if self.offset:
+                event1 = cl.enqueue_copy(queue or self.queue, self.base_data, ary,
+                        device_offset=self.offset,
+                        is_blocking=not async_)
+            else:
+                event1 = cl.enqueue_copy(queue or self.queue, self.base_data, ary,
+                        is_blocking=not async_)
+
             self.add_event(event1)
 
     def _get(self, queue=None, ary=None, async_=None, **kwargs):
@@ -770,9 +775,14 @@ class Array:
                     "to associate one.")
 
         if self.size:
-            event1 = cl.enqueue_copy(queue, ary, self.base_data,
-                    device_offset=self.offset,
-                    wait_for=self.events, is_blocking=not async_)
+            if self.offset:
+                event1 = cl.enqueue_copy(queue, ary, self.base_data,
+                        device_offset=self.offset,
+                        wait_for=self.events, is_blocking=not async_)
+            else:
+                event1 = cl.enqueue_copy(queue, ary, self.base_data,
+                        wait_for=self.events, is_blocking=not async_)
+
             self.add_event(event1)
         else:
             event1 = None

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -1458,8 +1458,8 @@ class Array:
         # https://github.com/inducer/pyopencl/issues/395
         if cl_version_gtr_1_2 and not (on_nvidia and self.nbytes >= 2**31):
             self.add_event(
-                    cl.enqueue_fill_buffer(queue, self.base_data, np.int8(0),
-                        self.offset, self.nbytes, wait_for=wait_for))
+                    cl.enqueue_fill(queue, self.base_data, np.int8(0),
+                        self.nbytes, offset=self.offset, wait_for=wait_for))
         else:
             zero = np.zeros((), self.dtype)
             self.fill(zero, queue=queue)

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -67,6 +67,25 @@ from pyopencl._cl import (  # noqa
 # }}}
 
 
+# {{{ svm allocator
+
+# FIXME: Replace me with C++
+class SVMAllocator:
+    def __init__(self, ctx, flags, *, alignment=0, queue=None):
+        self._context = ctx
+        self._flags = flags
+        self._alignment = alignment
+        self._queue = queue
+
+    def __call__(self, nbytes):
+        import pyopencl as cl
+        return cl.SVM(cl.svm_empty(
+                self._context, self._flags, (nbytes,), np.int8, "C", self._alignment,
+                self._queue))
+
+# }}}
+
+
 # {{{ first-arg caches
 
 _first_arg_dependent_caches = []

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -79,9 +79,9 @@ class SVMAllocator:
 
     def __call__(self, nbytes):
         import pyopencl as cl
-        return cl.SVM(cl.svm_empty(
-                self._context, self._flags, (nbytes,), np.int8, "C", self._alignment,
-                self._queue))
+        return cl.SVMAllocation(
+                self._context, nbytes, self._alignment, self._flags,
+                queue=self._queue)
 
 # }}}
 

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -60,6 +60,7 @@ _register_types()
 
 from pyopencl._cl import (  # noqa
         PooledBuffer as PooledBuffer,
+        SVMPooledAllocation as SVMPooledAllocation,
         _tools_DeferredAllocator as DeferredAllocator,
         _tools_ImmediateAllocator as ImmediateAllocator,
         _tools_SVMAllocator as SVMAllocator,

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -62,7 +62,9 @@ from pyopencl._cl import (  # noqa
         PooledBuffer as PooledBuffer,
         _tools_DeferredAllocator as DeferredAllocator,
         _tools_ImmediateAllocator as ImmediateAllocator,
-        MemoryPool as MemoryPool)
+        _tools_SVMAllocator as SVMAllocator,
+        MemoryPool as MemoryPool,
+        SVMMemoryPool as SVMMemoryPool)
 
 # }}}
 

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -71,19 +71,19 @@ from pyopencl._cl import (  # noqa
 
 # {{{ svm allocator
 
-# FIXME: Replace me with C++
-class SVMAllocator:
-    def __init__(self, ctx, flags, *, alignment=0, queue=None):
-        self._context = ctx
-        self._flags = flags
-        self._alignment = alignment
-        self._queue = queue
+# # FIXME: Replace me with C++
+# class SVMAllocator:
+#     def __init__(self, ctx, flags, *, alignment=0, queue=None):
+#         self._context = ctx
+#         self._flags = flags
+#         self._alignment = alignment
+#         self._queue = queue
 
-    def __call__(self, nbytes):
-        import pyopencl as cl
-        return cl.SVMAllocation(
-                self._context, nbytes, self._alignment, self._flags,
-                queue=self._queue)
+#     def __call__(self, nbytes):
+#         import pyopencl as cl
+#         return cl.SVMAllocation(
+#                 self._context, nbytes, self._alignment, self._flags,
+#                 queue=self._queue)
 
 # }}}
 

--- a/src/wrap_cl.hpp
+++ b/src/wrap_cl.hpp
@@ -496,6 +496,19 @@ namespace pyopencl
   // }}}
 
 
+  // {{{ utility functions
+
+  inline bool is_queue_in_order(cl_command_queue queue)
+  {
+      cl_command_queue_properties param_value;
+      PYOPENCL_CALL_GUARDED(clGetCommandQueueInfo,
+          (queue, CL_QUEUE_PROPERTIES, sizeof(param_value), &param_value, 0));
+      return !(param_value & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE);
+  }
+
+  // }}}
+
+
   // {{{ buffer interface helper
 
 

--- a/src/wrap_cl.hpp
+++ b/src/wrap_cl.hpp
@@ -137,10 +137,8 @@
 // }}}
 
 
+// {{{ macros and typedefs for wrappers
 
-
-
-// {{{ tools
 #if PY_VERSION_HEX >= 0x02050000
   typedef Py_ssize_t PYOPENCL_BUFFER_SIZE_T;
 #else
@@ -262,6 +260,7 @@
 
 // }}}
 
+
 // {{{ tracing and error reporting
 #ifdef PYOPENCL_TRACE
   #define PYOPENCL_PRINT_CALL_TRACE(NAME) \
@@ -329,6 +328,7 @@
 
 // }}}
 
+
 // {{{ get_info helpers
 #define PYOPENCL_GET_OPAQUE_INFO(WHAT, FIRST_ARG, SECOND_ARG, CL_TYPE, TYPE) \
   { \
@@ -383,6 +383,7 @@
 
 // }}}
 
+
 // {{{ event helpers --------------------------------------------------------------
 #define PYOPENCL_PARSE_WAIT_FOR \
     cl_uint num_events_in_wait_list = 0; \
@@ -424,7 +425,9 @@
 
 // }}}
 
+
 // {{{ equality testing
+
 #define PYOPENCL_EQUALITY_TESTS(cls) \
     bool operator==(cls const &other) const \
     { return data() == other.data(); } \
@@ -432,8 +435,8 @@
     { return data() != other.data(); } \
     long hash() const \
     { return (long) (intptr_t) data(); }
-// }}}
 
+// }}}
 
 
 namespace pyopencl

--- a/src/wrap_cl_part_2.cpp
+++ b/src/wrap_cl_part_2.cpp
@@ -305,7 +305,13 @@ void pyopencl_expose_part_2(py::module &m)
   {
     typedef svm_allocation cls;
     py::class_<cls>(m, "SVMAllocation", py::dynamic_attr())
-      .def(py::init<std::shared_ptr<context>, size_t, cl_uint, cl_svm_mem_flags>())
+      .def(py::init<std::shared_ptr<context>, size_t, cl_uint, cl_svm_mem_flags, const command_queue *>(),
+          py::arg("context"),
+          py::arg("size"),
+          py::arg("alignment"),
+          py::arg("flags"),
+          py::arg("queue").none(true)=py::none()
+          )
       .DEF_SIMPLE_METHOD(release)
       .def("enqueue_release", &cls::enqueue_release,
           ":returns: a :class:`pyopencl.Event`\n\n"
@@ -314,6 +320,8 @@ void pyopencl_expose_part_2(py::module &m)
       .def(py::self == py::self)
       .def(py::self != py::self)
       .def("__hash__", &cls::ptr_as_int)
+      .DEF_SIMPLE_METHOD(bind_to_queue)
+      .DEF_SIMPLE_METHOD(unbind_from_queue)
       ;
   }
 

--- a/src/wrap_cl_part_2.cpp
+++ b/src/wrap_cl_part_2.cpp
@@ -299,6 +299,7 @@ void pyopencl_expose_part_2(py::module &m)
     typedef svm_arg_wrapper cls;
     py::class_<cls>(m, "SVM", py::dynamic_attr())
       .def(py::init<py::object>())
+      .def("_ptr_as_int", [](cls &self) { return (intptr_t) self.ptr(); })
       .def("_size", &cls::size)
       ;
   }

--- a/src/wrap_cl_part_2.cpp
+++ b/src/wrap_cl_part_2.cpp
@@ -299,6 +299,7 @@ void pyopencl_expose_part_2(py::module &m)
     typedef svm_arg_wrapper cls;
     py::class_<cls>(m, "SVM", py::dynamic_attr())
       .def(py::init<py::object>())
+      .def("_size", &cls::size)
       ;
   }
 

--- a/src/wrap_mempool.cpp
+++ b/src/wrap_mempool.cpp
@@ -307,13 +307,15 @@ namespace
   {
     protected:
       std::shared_ptr<pyopencl::context> m_context;
+      pyopencl::command_queue m_queue;
       cl_uint m_alignment;
       cl_mem_flags m_flags;
 
     public:
       svm_allocator(std::shared_ptr<pyopencl::context> const &ctx,
+          pyopencl::command_queue &queue,
           cl_uint alignment, cl_mem_flags flags=CL_MEM_READ_WRITE)
-        : m_context(ctx), m_alignment(alignment), m_flags(flags)
+        : m_context(ctx), m_queue(queue), m_alignment(alignment), m_flags(flags)
       {
         if (flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR))
           throw pyopencl::error("Allocator", CL_INVALID_VALUE,
@@ -321,7 +323,7 @@ namespace
       }
 
       svm_allocator(svm_allocator const &src)
-      : m_context(src.m_context), m_alignment(src.m_alignment),
+      : m_context(src.m_context), m_queue(src.m_queue), m_alignment(src.m_alignment),
       m_flags(src.m_flags)
       { }
 
@@ -544,7 +546,11 @@ void pyopencl_expose_mempool(py::module &m)
         m, "_tools_SVMAllocator");
     wrapper
       .def(py::init<svm_allocator &>())
-      .def(py::init<std::shared_ptr<pyopencl::context> const &, cl_uint, cl_mem_flags>())
+      .def(py::init<std::shared_ptr<pyopencl::context> const &, pyopencl::command_queue &, cl_uint, cl_mem_flags>(),
+      py::arg("ctx"),
+      py::arg("queue"),
+      py::arg("alignment")=0,
+      py::arg("flags")=CL_MEM_READ_WRITE)
       ;
   }
 

--- a/src/wrap_mempool.cpp
+++ b/src/wrap_mempool.cpp
@@ -70,6 +70,8 @@ namespace
   };
 
 
+  // {{{ cl allocators
+
   class cl_allocator_base
   {
     protected:
@@ -210,8 +212,10 @@ namespace
       }
   };
 
+  // }}}
 
 
+  // {{{ allocator_call
 
   inline
   pyopencl::buffer *allocator_call(cl_allocator_base &alloc, size_t size)
@@ -256,8 +260,10 @@ namespace
     }
   }
 
+  // }}}
 
 
+  // {{{ pooled_buffer
 
   class pooled_buffer
     : public pyopencl::pooled_allocation<pyopencl::memory_pool<cl_allocator_base> >,
@@ -278,8 +284,10 @@ namespace
       { return ptr(); }
   };
 
+  // }}}
 
 
+  // {{{{ device_pool_allocate
 
   pooled_buffer *device_pool_allocate(
       std::shared_ptr<pyopencl::memory_pool<cl_allocator_base> > pool,
@@ -287,6 +295,9 @@ namespace
   {
     return new pooled_buffer(pool, sz);
   }
+
+  // }}}
+
 
 
 
@@ -398,3 +409,5 @@ void pyopencl_expose_mempool(py::module &m)
       ;
   }
 }
+
+// vim: foldmethod=marker


### PR DESCRIPTION
PR on top of #452 

-----

This currently fails with  

```
File "/shared/home/mdiener/Work/emirge/grudge/examples/wave/wave-op-mpi.py", line 351, in <module>
    main(cl.create_some_context,
  File "/shared/home/mdiener/Work/emirge/grudge/examples/wave/wave-op-mpi.py", line 213, in main
    allocator=cl_tools.SVMMemoryPool(cl_tools.SVMAllocator(cl_ctx, cl.svm_mem_flags.READ_WRITE, queue=queue)),
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. pyopencl._cl.SVMMemoryPool(allocator: pyopencl._cl._tools_SVMAllocator, leading_bits_in_bin_id: int = 4)

Invoked with: <pyopencl.tools.SVMAllocator object at 0x7fadda3eb940>
```

cc @inducer @lukeolson