### PR TITLE
Implement dedicated kernels for `{min,max}imum`

### DIFF
--- a/pyopencl/reduction.py
+++ b/pyopencl/reduction.py
@@ -628,6 +628,13 @@ def get_subset_dot_kernel(ctx, dtype_out, dtype_subset, dtype_a=None, dtype_b=No
                     }))
 
 
+_MINMAX_PREAMBLE = """
+#define MY_INFINITY (1./0)
+#define fmin_nanprop(a, b) (isnan(a) || isnan(b)) ? a+b : fmin(a, b)
+#define fmax_nanprop(a, b) (isnan(a) || isnan(b)) ? a+b : fmax(a, b)
+"""
+
+
 def get_minmax_neutral(what, dtype):
     dtype = np.dtype(dtype)
     if issubclass(dtype.type, np.inexact):
@@ -660,11 +667,7 @@ def get_minmax_kernel(ctx, what, dtype):
             reduce_expr=f"{reduce_expr}",
             arguments="const {tp} *in".format(
                 tp=dtype_to_ctype(dtype),
-                ), preamble="""
-                #define MY_INFINITY (1./0)
-                #define fmin_nanprop(a, b) (isnan(a) || isnan(b)) ? a+b : fmin(a, b)
-                #define fmax_nanprop(a, b) (isnan(a) || isnan(b)) ? a+b : fmax(a, b)
-                """)
+                ), preamble=_MINMAX_PREAMBLE)
 
 
 @context_dependent_memoize
@@ -686,7 +689,7 @@ def get_subset_minmax_kernel(ctx, what, dtype, dtype_subset):
                     "tp": dtype_to_ctype(dtype),
                     "tp_lut": dtype_to_ctype(dtype_subset),
                     }),
-            preamble="#define MY_INFINITY (1./0)")
+            preamble=_MINMAX_PREAMBLE)
 
 # }}}
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -1847,12 +1847,31 @@ def test_branch_operations_on_pure_scalars():
     cl_array.maximum,
     cl_array.minimum,
 ])
-def test_branch_operations_on_nans(ctx_factory, op):
+@pytest.mark.parametrize("special_a", [
+    np.nan,
+    np.inf,
+    -np.inf,
+])
+@pytest.mark.parametrize("special_b", [
+    np.nan,
+    np.inf,
+    -np.inf,
+    None
+])
+def test_branch_operations_on_nans(ctx_factory, op, special_a, special_b):
     ctx = ctx_factory()
     cq = cl.CommandQueue(ctx)
 
-    x_np = np.array([np.nan, 1., np.nan, 2.], dtype=np.float64)
-    y_np = np.array([np.nan, np.nan, 1., 3.], dtype=np.float64)
+    def sb_or(x):
+        if special_b is None:
+            return x
+        else:
+            return special_b
+
+    x_np = np.array([special_a, sb_or(1.), special_a, sb_or(2.), sb_or(3.)],
+            dtype=np.float64)
+    y_np = np.array([special_a, special_a, sb_or(1.), sb_or(3.), sb_or(2.)],
+            dtype=np.float64)
 
     x_cl = cl_array.to_device(cq, x_np)
     y_cl = cl_array.to_device(cq, y_np)


### PR DESCRIPTION
@majosm Turns out #584 mishandled infinities, which are used frequently as neutral elements.
@matthiasdiener This may be behind the NaNs that we were seeing, i.e. unrelated to the memory pool.