### PR TITLE
Revert "Use pocl dev label for Conda CI"

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -1,8 +1,5 @@
 name: test-conda-env
 channels:
-# For https://github.com/pocl/pocl/pull/1069
-# See https://github.com/conda-forge/pocl-feedstock/pull/80
-- conda-forge/label/pocl_dev
 - conda-forge
 - nodefaults
 


### PR DESCRIPTION
This reverts commit c256f4fa7f4e83ee8ccacce2b84fdb7bcc4d74af.