### PR TITLE
Add events to ElementwiseKernel args

### DIFF
--- a/test/test_algorithm.py
+++ b/test/test_algorithm.py
@@ -59,7 +59,8 @@ def test_elwise_kernel(ctx_factory):
             "linear_combination")
 
     c_gpu = cl_array.empty_like(a_gpu)
-    lin_comb(5, a_gpu, 6, b_gpu, c_gpu)
+    evt = lin_comb(5, a_gpu, 6, b_gpu, c_gpu)
+    assert evt in c_gpu.events
 
     assert la.norm((c_gpu - (5 * a_gpu + 6 * b_gpu)).get()) < 1e-5
 


### PR DESCRIPTION
This is what I was trying to ask today, i.e. if the input / output args of `ElementwiseKernel` get the event that gets generated. Currently they do not. Should they?

For context, this is about removing the manual event handling in `boxtree` for something like the `GappyCopyAndMapKernel`
https://github.com/inducer/boxtree/blob/529e8d62f365350a80c9f16a0b12b9fb2c1a140e/boxtree/tools.py#L453-L509
which has a bunch of arguments.