### PR TITLE
Fix sphinx directive

### DIFF
--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -209,9 +209,17 @@ and then use the ``%%cl_kernel`` 'cell-magic' command. See `this notebook
 <http://nbviewer.ipython.org/urls/raw.githubusercontent.com/inducer/pyopencl/master/examples/ipython-demo.ipynb>`_
 (which ships with PyOpenCL) for a demonstration.
 
-You can pass build options to be used for building the program executable by using the ``-o`` flag on the first line of the cell (next to the ``%%cl_kernel`` directive). For example: `%%cl_kernel -o "-cl-fast-relaxed-math"``.
+You can pass build options to be used for building the program executable by
+using the ``-o`` flag on the first line of the cell (next to the ``%%cl_kernel``
+directive). For example::
 
-There are also line magics: ``cl_load_edit_kernel`` which will load a file into the next cell (adding ``cl_kernel`` to the first line) and ``cl_kernel_from_file`` which will compile kernels from a file (as if you copy-and-pasted the contents of the file to a cell with ``cl_kernel``). Both of these magics take options ``-f`` to specify the file and optionally ``-o`` for build options.
+    %%cl_kernel -o "-cl-fast-relaxed-math"
+
+There are also line magics: ``cl_load_edit_kernel`` which will load a file into
+the next cell (adding ``cl_kernel`` to the first line) and ``cl_kernel_from_file``
+which will compile kernels from a file (as if you copy-and-pasted the contents of
+the file to a cell with ``cl_kernel``). Both of these magics take options ``-f``
+to specify the file and optionally ``-o`` for build options.
 
 .. versionadded:: 2014.1
 

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -500,7 +500,7 @@ Version 2011.2
 * Add :mod:`pyopencl.characterize`.
 * Ensure compatibility with OS X Lion.
 * Add :func:`pyopencl.tools.register_dtype` to enable scan/reduction on struct types.
-* :func:``pyopencl.enqueue_migrate_mem_objects`` was renamed
+* :func:`pyopencl.enqueue_migrate_mem_objects` was renamed
   ``pyopencl.enqueue_migrate_mem_objects_ext``.
   :func:`pyopencl.enqueue_migrate_mem_objects` now refers to the OpenCL 1.2 function
   of this name, if available.

--- a/examples/gl_particle_animation.py
+++ b/examples/gl_particle_animation.py
@@ -174,11 +174,11 @@ cl_start_velocity = cl.Buffer(
 cl_gl_position = cl.GLBuffer(context, mf.READ_WRITE, int(gl_position))
 cl_gl_color = cl.GLBuffer(context, mf.READ_WRITE, int(gl_color))
 
-kernel = """__kernel void particle_fountain(__global float4* position, 
-                                            __global float4* color, 
-                                            __global float4* velocity, 
-                                            __global float4* start_position, 
-                                            __global float4* start_velocity, 
+kernel = """__kernel void particle_fountain(__global float4* position,
+                                            __global float4* color,
+                                            __global float4* velocity,
+                                            __global float4* start_position,
+                                            __global float4* start_velocity,
                                             float time_step)
 {
     unsigned int i = get_global_id(0);
@@ -190,7 +190,7 @@ kernel = """__kernel void particle_fountain(__global float4* position,
     {
         p = start_position[i];
         v = start_velocity[i];
-        life = 1.0f;    
+        life = 1.0f;
     }
 
     v.z -= 9.8f*time_step;


### PR DESCRIPTION
Was testing out https://github.com/sphinx-contrib/sphinx-lint

`sphinx-lint` also seems to report trailing spaces in comments in `.py` files, which is.. odd.