### PR TITLE
Add MemoryObjectHolder to docs

### DIFF
--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -853,6 +853,10 @@ Internal Types
 
     See :class:`pyopencl.MemoryMap`.
 
+.. class:: MemoryObjectHolder
+
+    See :class:`pyopencl.MemoryObjectHolder`.
+
 .. class:: Sampler
 
     See :class:`pyopencl.Sampler`.

--- a/doc/runtime_memory.rst
+++ b/doc/runtime_memory.rst
@@ -5,6 +5,8 @@ OpenCL Runtime: Memory
 
 .. currentmodule:: pyopencl
 
+.. class:: MemoryObjectHolder
+
 .. class:: MemoryObject
 
     .. attribute:: info

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -2047,7 +2047,7 @@ def enqueue_copy(queue, dest, src, **kwargs):
 # {{{ enqueue_fill
 
 def enqueue_fill(queue: CommandQueue,
-        dest: "Union[MemoryObjectHolder, SVMPointer]",
+        dest: Union[MemoryObjectHolder, "SVMPointer"],
         pattern: Any, size: int, *, offset: int = 0,
         wait_for: Optional[Sequence[Event]] = None) -> Event:
     """

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -525,22 +525,22 @@ class Array:
 
     def __init__(
             self,
-            cq: Optional[Union["cl.Context", "cl.CommandQueue"]],
+            cq: Optional[Union[cl.Context, cl.CommandQueue]],
             shape: Union[Tuple[int, ...], int],
             dtype: Any,
             order: str = "C",
-            allocator: Optional["cl.tools.AllocatorBase"] = None,
+            allocator: Optional[cl.tools.AllocatorBase] = None,
             data: Any = None,
             offset: int = 0,
             strides: Optional[Tuple[int, ...]] = None,
-            events: Optional[List["cl.Event"]] = None,
+            events: Optional[List[cl.Event]] = None,
 
             # NOTE: following args are used for the fast constructor
             _flags: Any = None,
             _fast: bool = False,
             _size: Optional[int] = None,
-            _context: Optional["cl.Context"] = None,
-            _queue: Optional["cl.CommandQueue"] = None) -> None:
+            _context: Optional[cl.Context] = None,
+            _queue: Optional[cl.CommandQueue] = None) -> None:
         if _fast:
             # Assumptions, should be disabled if not testing
             if 0:


### PR DESCRIPTION
This was used in `enqueue_fill` but wouldn't link. `sphinx` would throw a warning when ran with
```
make html SPHINXOPTS="-W --keep-going -n -Dautodoc_typehints=both"
```

`enqueue_fill` doesn't pick up the arguments from the function because it's defined as
```
.. autofunction:: enqueue_fill(queue, dest, src, **kwargs)
```
so not quite sure if this is wanted?