### PR TITLE
Fix alignment of cdouble_t and cfloat_t

### DIFF
--- a/pyopencl/cl/pyopencl-complex.h
+++ b/pyopencl/cl/pyopencl-complex.h
@@ -274,11 +274,19 @@
     } \
   } \
 
+#if PYOPENCL_COMPLEX_ENABLE_EXTENDED_ALIGNMENT
+#define _PYOPENCL_COMPLEX_ALIGNMENT(TYPE) 2*sizeof(TYPE)
+#else
+#define _PYOPENCL_COMPLEX_ALIGNMENT(TYPE) sizeof(TYPE)
+#endif
+
 #define PYOPENCL_DECLARE_COMPLEX_TYPE(BASE, BASE_3LTR) \
   typedef union \
   { \
-    struct { BASE x, y; }; \
-    struct { BASE real, imag; }; \
+    struct { BASE x, y; } \
+      __attribute__ ((aligned (_PYOPENCL_COMPLEX_ALIGNMENT(BASE)))); \
+    struct { BASE real, imag; } \
+      __attribute__ ((aligned (_PYOPENCL_COMPLEX_ALIGNMENT(BASE)))); \
   } c##BASE##_t; \
   \
   PYOPENCL_DECLARE_COMPLEX_TYPE_INT(BASE, BASE_3LTR, c##BASE, c##BASE##_t)

--- a/pyopencl/cl/pyopencl-complex.h
+++ b/pyopencl/cl/pyopencl-complex.h
@@ -274,6 +274,7 @@
     } \
   } \
 
+// This is undocumented and may disappear at any time
 #if PYOPENCL_COMPLEX_ENABLE_EXTENDED_ALIGNMENT
 #define PYOPENCL_COMPLEX_ALIGNMENT(TYPE) 2*sizeof(TYPE)
 #else

--- a/pyopencl/cl/pyopencl-complex.h
+++ b/pyopencl/cl/pyopencl-complex.h
@@ -275,18 +275,18 @@
   } \
 
 #if PYOPENCL_COMPLEX_ENABLE_EXTENDED_ALIGNMENT
-#define _PYOPENCL_COMPLEX_ALIGNMENT(TYPE) 2*sizeof(TYPE)
+#define PYOPENCL_COMPLEX_ALIGNMENT(TYPE) 2*sizeof(TYPE)
 #else
-#define _PYOPENCL_COMPLEX_ALIGNMENT(TYPE) sizeof(TYPE)
+#define PYOPENCL_COMPLEX_ALIGNMENT(TYPE) sizeof(TYPE)
 #endif
 
 #define PYOPENCL_DECLARE_COMPLEX_TYPE(BASE, BASE_3LTR) \
   typedef union \
   { \
     struct { BASE x, y; } \
-      __attribute__ ((aligned (_PYOPENCL_COMPLEX_ALIGNMENT(BASE)))); \
+      __attribute__ ((aligned (PYOPENCL_COMPLEX_ALIGNMENT(BASE)))); \
     struct { BASE real, imag; } \
-      __attribute__ ((aligned (_PYOPENCL_COMPLEX_ALIGNMENT(BASE)))); \
+      __attribute__ ((aligned (PYOPENCL_COMPLEX_ALIGNMENT(BASE)))); \
   } c##BASE##_t; \
   \
   PYOPENCL_DECLARE_COMPLEX_TYPE_INT(BASE, BASE_3LTR, c##BASE, c##BASE##_t)
@@ -298,3 +298,5 @@ PYOPENCL_DECLARE_COMPLEX_TYPE(float, FLT);
 PYOPENCL_DECLARE_COMPLEX_TYPE(double, DBL);
 #define cdouble_cast(a) cdouble_new((a).real, (a).imag)
 #endif
+
+#undef PYOPENCL_COMPLEX_ALIGNMENT


### PR DESCRIPTION
Can see a 10% speed boost in M2L kernel in sumpy.

alignment is extended when `PYOPENCL_COMPLEX_ENABLE_EXTENDED_ALIGNMENT` is defined