### PR TITLE
Fix some dead links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,7 +24,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 PyOpenCL includes derivatives of parts of the `Thrust
-<https://github.com/thrust/thrust/>`_ computing package (in particular the scan
+<https://github.com/NVIDIA/thrust>`_ computing package (in particular the scan
 implementation). These parts are licensed as follows:
 
     Copyright 2008-2011 NVIDIA Corporation
@@ -33,7 +33,7 @@ implementation). These parts are licensed as follows:
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        <http://www.apache.org/licenses/LICENSE-2.0>
+        <https://www.apache.org/licenses/LICENSE-2.0>
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ PyOpenCL: Pythonic Access to OpenCL, with Arrays and Algorithms
 .. image:: https://github.com/inducer/pyopencl/workflows/CI/badge.svg?branch=main&event=push
     :alt: Github Build Status
     :target: https://github.com/inducer/pyopencl/actions?query=branch%3Amain+workflow%3ACI+event%3Apush
-.. image:: https://badge.fury.io/py/pyopencl.png
+.. image:: https://badge.fury.io/py/pyopencl.svg
     :alt: Python Package Index Release Page
     :target: https://pypi.org/project/pyopencl/
 .. image:: https://zenodo.org/badge/1575307.svg

--- a/doc/algorithm.rst
+++ b/doc/algorithm.rst
@@ -119,7 +119,7 @@ in PyOpenCL:
 * Segmented scans
 
 * Access to the previous item in *input_expr* (e.g. for comparisons)
-  See the `implementation <https://github.com/inducer/pyopencl/blob/master/pyopencl/scan.py#L1353>`_
+  See the `implementation <https://github.com/inducer/pyopencl/blob/36afe57784368e8d2505bc7cad8df964ba3c0264/pyopencl/algorithm.py#L226>`__
   of :func:`pyopencl.algorithm.unique` for an example.
 
 Making Custom Scan Kernels
@@ -141,7 +141,8 @@ Simple / Legacy Interface
 
 .. class:: ExclusiveScanKernel(ctx, dtype, scan_expr, neutral, name_prefix="scan", options=[], preamble="", devices=None)
 
-    Generates a kernel that can compute a `prefix sum <https://secure.wikimedia.org/wikipedia/en/wiki/Prefix_sum>`_
+    Generates a kernel that can compute a `prefix sum
+    <https://en.wikipedia.org/wiki/Prefix_sum>`__
     using any associative operation given as *scan_expr*.
     *scan_expr* uses the formal values "a" and "b" to indicate two operands of
     an associative binary operation. *neutral* is the neutral element

--- a/doc/algorithm.rst
+++ b/doc/algorithm.rst
@@ -74,7 +74,7 @@ difficult to parallelize because of loop-carried dependencies.
 
 .. seealso::
 
-    `Prefix sums and their applications <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.128.6230>`_, by Guy Blelloch.
+    `Prefix sums and their applications <https://doi.org/10.1184/R1/6608579.v1>`__, by Guy Blelloch.
         This article gives an overview of some surprising applications of scans.
 
     :ref:`predefined-scans`

--- a/doc/array.rst
+++ b/doc/array.rst
@@ -101,7 +101,7 @@ functions defined on them such as `cfloat_mul(a, b)` or `cdouble_log(z)`.
 Elementwise kernels automatically include the header if your kernel has
 complex input or output.
 See the `source file
-<https://github.com/inducer/pyopencl/blob/master/pyopencl/cl/pyopencl-complex.h>`_
+<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-complex.h>`_
 for a precise list of what's available.
 
 If you need double precision support, please::

--- a/doc/array.rst
+++ b/doc/array.rst
@@ -101,7 +101,7 @@ functions defined on them such as `cfloat_mul(a, b)` or `cdouble_log(z)`.
 Elementwise kernels automatically include the header if your kernel has
 complex input or output.
 See the `source file
-<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-complex.h>`_
+<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-complex.h>`__
 for a precise list of what's available.
 
 If you need double precision support, please::

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -34,7 +34,7 @@ lines:
 
 Since OpenCL C may have a different opinion for :mod:`numpy` on how the struct
 should be laid out, for example because of `alignment
-<https://en.wikipedia.org/wiki/Data_structure_alignment>`_. So as a first step, we
+<https://en.wikipedia.org/wiki/Data_structure_alignment>`__. So as a first step, we
 match our dtype against CL's version:
 
 .. doctest::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,7 +54,7 @@ Tutorials
   `4 <https://www.youtube.com/watch?v=SsuJ0LvZW1Q>`__
   (YouTube, 2011)
 * PyOpenCL course at `DTU GPULab <http://gpulab.compute.dtu.dk/>`__ and
-  `Simula <https://www.simula.no/>`_ (2011):
+  `Simula <https://www.simula.no/>`__ (2011):
   `Lecture 1 <https://tiker.net/pub/simula-pyopencl-lec1.pdf>`__
   `Lecture 2 <https://tiker.net/pub/simula-pyopencl-lec2.pdf>`__
   `Problem set 1 <https://tiker.net/pub/simula-pyopencl-probset1.pdf>`__

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,12 +2,12 @@ Welcome to PyOpenCL's documentation!
 ====================================
 
 PyOpenCL gives you easy, Pythonic access to the `OpenCL
-<http://www.khronos.org/opencl/>`_ parallel computation API.
+<https://www.khronos.org/opencl/>`__ parallel computation API.
 What makes PyOpenCL special?
 
 * Object cleanup tied to lifetime of objects. This idiom,
   often called
-  `RAII <http://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization>`_
+  `RAII <https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization>`__
   in C++, makes it much easier to write correct, leak- and
   crash-free code.
 
@@ -39,57 +39,60 @@ Tutorials
 =========
 
 * Gaston Hillar's `two-part article series
-  <http://web.archive.org/web/20190707171427/www.drdobbs.com/open-source/easy-opencl-with-python/240162614>`_
+  <https://web.archive.org/web/20190707171427/www.drdobbs.com/open-source/easy-opencl-with-python/240162614>`__
   in Dr. Dobb's Journal provides a friendly introduction to PyOpenCL.
-* `Simon McIntosh-Smith <http://www.cs.bris.ac.uk/~simonm/>`_
-  and `Tom Deakin <http://www.tomdeakin.com/>`_'s course
-  `Hands-on OpenCL <http://handsonopencl.github.io/>`_ contains
-  both `lecture slides <https://github.com/HandsOnOpenCL/Lecture-Slides/releases>`_
-  and `exercises (with solutions) <https://github.com/HandsOnOpenCL/Exercises-Solutions>`_
+* `Simon McIntosh-Smith <http://people.cs.bris.ac.uk/~simonm/>`__
+  and `Tom Deakin <https://www.tomdeakin.com/>`__'s course
+  `Hands-on OpenCL <https://handsonopencl.github.io/>`__ contains
+  both `lecture slides <https://github.com/HandsOnOpenCL/Lecture-Slides/releases>`__
+  and `exercises (with solutions) <https://github.com/HandsOnOpenCL/Exercises-Solutions>`__
   (The course covers PyOpenCL as well as OpenCL's C and C++ APIs.)
-* PyOpenCL course at `PASI <http://bu.edu/pasi>`_: Parts
-  `1 <https://www.youtube.com/watch?v=X9mflbX1NL8>`_
-  `2 <https://www.youtube.com/watch?v=MqvfCE_bKOg>`_
-  `3 <https://www.youtube.com/watch?v=TAvKmV7CuUw>`_
-  `4 <https://www.youtube.com/watch?v=SsuJ0LvZW1Q>`_
+* PyOpenCL course at `PASI <https://www.bu.edu/pasi>`__: Parts
+  `1 <https://www.youtube.com/watch?v=X9mflbX1NL8>`__
+  `2 <https://www.youtube.com/watch?v=MqvfCE_bKOg>`__
+  `3 <https://www.youtube.com/watch?v=TAvKmV7CuUw>`__
+  `4 <https://www.youtube.com/watch?v=SsuJ0LvZW1Q>`__
   (YouTube, 2011)
-* PyOpenCL course at `DTU GPULab <http://gpulab.imm.dtu.dk/>`_ and
-  `Simula <http://simula.no/>`_ (2011):
-  `Lecture 1 <http://tiker.net/pub/simula-pyopencl-lec1.pdf>`_
-  `Lecture 2 <http://tiker.net/pub/simula-pyopencl-lec2.pdf>`_
-  `Problem set 1 <http://tiker.net/pub/simula-pyopencl-probset1.pdf>`_
-  `Problem set 2 <http://tiker.net/pub/simula-pyopencl-probset2.pdf>`_
-* Ian Johnson's `PyOpenCL tutorial <https://web.archive.org/web/20170907175053/http://enja.org:80/2011/02/22/adventures-in-pyopencl-part-1-getting-started-with-python>`_.
+* PyOpenCL course at `DTU GPULab <http://gpulab.compute.dtu.dk/>`__ and
+  `Simula <https://www.simula.no/>`_ (2011):
+  `Lecture 1 <https://tiker.net/pub/simula-pyopencl-lec1.pdf>`__
+  `Lecture 2 <https://tiker.net/pub/simula-pyopencl-lec2.pdf>`__
+  `Problem set 1 <https://tiker.net/pub/simula-pyopencl-probset1.pdf>`__
+  `Problem set 2 <https://tiker.net/pub/simula-pyopencl-probset2.pdf>`__
+* Ian Johnson's `PyOpenCL tutorial <https://web.archive.org/web/20170907175053/http://enja.org:80/2011/02/22/adventures-in-pyopencl-part-1-getting-started-with-python>`__.
 
 Software that works with or enhances PyOpenCL
 =============================================
 
-* Jon Roose's `pyclblas <https://pyclblas.readthedocs.io/en/latest/index.html>`_
-  (`code <https://github.com/jroose/pyclblas>`_)
-  makes BLAS in the form of `clBLAS <https://github.com/clMathLibraries/clBLAS>`_
+* Jon Roose's `pyclblas <https://pyclblas.readthedocs.io/en/latest/index.html>`__
+  (`code <https://github.com/jroose/pyclblas>`__)
+  makes BLAS in the form of `clBLAS <https://github.com/clMathLibraries/clBLAS>`__
   available from within :mod:`pyopencl` code.
 
   Two earlier wrappers continue to be available:
-  one by `Eric Hunsberger <https://github.com/hunse/pyopencl_blas>`_ and one
-  by `Lars Ericson <http://lists.tiker.net/pipermail/pyopencl/2015-June/001890.html>`_.
+  one by `Eric Hunsberger <https://github.com/hunse/pyopencl_blas>`__ and one
+  by `Lars Ericson <https://lists.tiker.net/pipermail/pyopencl/2015-June/001890.html>`__.
 
-* Cedric Nugteren provides a wrapper for the `CLBlast <https://github.com/CNugteren/CLBlast>`_ OpenCL BLAS library: `PyCLBlast <https://github.com/CNugteren/CLBlast/tree/master/src/pyclblast>`_.
+* Cedric Nugteren provides a wrapper for the
+  `CLBlast <https://github.com/CNugteren/CLBlast>`__
+  OpenCL BLAS library:
+  `PyCLBlast <https://github.com/CNugteren/CLBlast/tree/master/src/pyclblast>`__.
 
-* Gregor Thalhammer's `gpyfft <https://github.com/geggo/gpyfft>`_ provides a
+* Gregor Thalhammer's `gpyfft <https://github.com/geggo/gpyfft>`__ provides a
   Python wrapper for the OpenCL FFT library clFFT from AMD.
 
-* Bogdan Opanchuk's `reikna <http://pypi.python.org/pypi/reikna>`_ offers a
+* Bogdan Opanchuk's `reikna <https://pypi.org/project/reikna/>`__ offers a
   variety of GPU-based algorithms (FFT, random number generation, matrix
   multiplication) designed to work with :class:`pyopencl.array.Array` objects.
 
 * Troels Henriksen, Ken Friis Larsen, and Cosmin Oancea's `Futhark
-  <http://futhark-lang.org/>`_ programming language offers a nice way to code
+  <https://futhark-lang.org/>`__ programming language offers a nice way to code
   nested-parallel programs with reductions and scans on data in
   :class:`pyopencl.array.Array` instances.
 
-* Robbert Harms and Alard Roebroeck's `MOT
-  <https://github.com/cbclab/MOT>`_ offers a variety of GPU-enabled non-linear optimization algorithms
-  and MCMC sampling routines for parallel optimization and sampling of multiple problems.
+* Robbert Harms and Alard Roebroeck's `MOT <https://github.com/robbert-harms/MOT>`__
+  offers a variety of GPU-enabled non-linear optimization algorithms and MCMC
+  sampling routines for parallel optimization and sampling of multiple problems.
 
 * Vincent Favre-Nicolin's `pyvkfft <https://github.com/vincefn/pyvkfft/>`__
   makes `vkfft <https://github.com/DTolm/VkFFT>`__ accessible from PyOpenCL.
@@ -120,10 +123,10 @@ Contents
     💾 Download Releases <https://pypi.org/project/pyopencl>
 
 Note that this guide does not explain OpenCL programming and technology. Please
-refer to the official `Khronos OpenCL documentation <http://khronos.org/opencl>`_
+refer to the official `Khronos OpenCL documentation <https://www.khronos.org/opencl/>`__
 for that.
 
-PyOpenCL also has its own `web site <http://mathema.tician.de/software/pyopencl>`_,
+PyOpenCL also has its own `web site <https://mathema.tician.de/software/pyopencl>`__,
 where you can find updates, new versions, documentation, and support.
 
 Indices and tables

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -14,7 +14,7 @@ package manager. The following instructions are aimed at Linux and macOS.
 The analogous steps for Windows should also work.
 
 Install a version of
-`miniforge <https://github.com/conda-forge/miniforge#miniforge3>`_
+`miniforge <https://github.com/conda-forge/miniforge#miniforge3>`__
 that fits your system::
 
     curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
@@ -72,7 +72,7 @@ On Linux, Windows and macOS, you can use Oclgrind to detect memory access errors
     conda install oclgrind
 
 You are now ready to run code based on PyOpenCL, such as the `code
-examples <https://github.com/inducer/pyopencl/tree/master/examples>`_.
+examples <https://github.com/inducer/pyopencl/tree/main/examples>`_.
 
 Using vendor-supplied OpenCL drivers (mainly on Linux)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ Syntax highlighting
 
 You can obtain Vim syntax highlighting for OpenCL C inlined in Python by
 checking `this file
-<https://github.com/inducer/pyopencl/blob/master/contrib/pyopencl.vim>`_.
+<https://github.com/inducer/pyopencl/blob/main/contrib/pyopencl.vim>`_.
 
 Note that the triple-quoted strings containing the source must start with
 `"""//CL// ..."""`.
@@ -206,7 +206,7 @@ IPython extension using::
     %load_ext pyopencl.ipython_ext
 
 and then use the ``%%cl_kernel`` 'cell-magic' command. See `this notebook
-<http://nbviewer.ipython.org/urls/raw.githubusercontent.com/inducer/pyopencl/master/examples/ipython-demo.ipynb>`_
+<https://nbviewer.org/github/inducer/pyopencl/blob/main/examples/ipython-demo.ipynb>`__
 (which ships with PyOpenCL) for a demonstration.
 
 You can pass build options to be used for building the program executable by
@@ -423,10 +423,10 @@ Version 2013.1
 * Add :func:`pyopencl.tools.match_dtype_to_c_struct`,
   for better integration of the CL and :mod:`numpy` type systems.
 * More/improved Bessel functions.
-  See `the source <https://github.com/inducer/pyopencl/tree/master/src/cl>`_.
+  See `the source <https://github.com/inducer/pyopencl/tree/main/pyopencl/cl>`__.
 * Add :envvar:`PYOPENCL_NO_CACHE` environment variable to aid debugging.
   (e.g. with AMD's CPU implementation, see
-  `their programming guide <http://developer.amd.com/sdks/AMDAPPSDK/assets/AMD_Accelerated_Parallel_Processing_OpenCL_Programming_Guide.pdf>`_)
+  `their programming guide <https://developer.amd.com/wordpress/media/2013/07/AMD_Accelerated_Parallel_Processing_OpenCL_Programming_Guide-rev-2.7.pdf>`__)
 * Deprecated :func:`pyopencl.tools.register_dtype` in favor of
   :func:`pyopencl.tools.get_or_register_dtype`.
 * Clean up the :class:`pyopencl.array.Array` constructor interface.
@@ -502,7 +502,7 @@ Version 2011.2
 * All comparable PyOpenCL objects are now also hashable.
 * Add ``pyopencl.tools.context_dependent_memoize`` to the documented
   functionality.
-* Base :mod:`pyopencl.clrandom` on `RANLUXCL <https://bitbucket.org/ivarun/ranluxcl>`_,
+* Base :mod:`pyopencl.clrandom` on RANLUXCL (``https://bitbucket.org/ivarun/ranluxcl>``),
   add functionality.
 * Add :class:`pyopencl.NannyEvent` objects.
 * Add :mod:`pyopencl.characterize`.
@@ -572,7 +572,7 @@ Version 0.92
   emphasize the importance of *local_size*.
 * Add :meth:`pyopencl.Kernel.set_scalar_arg_dtypes`.
 * Add support for the
-  `cl_nv_device_attribute_query <http://www.khronos.org/registry/cl/extensions/khr/cl_nv_device_attribute_query.txt>`_
+  `cl_nv_device_attribute_query <https://registry.khronos.org/OpenCL/extensions/nv/cl_nv_device_attribute_query.txt>`_
   extension.
 * Add :meth:`pyopencl.array.Array` and related functionality.
 * Make build not depend on Boost C++.
@@ -733,7 +733,7 @@ Contributors
 ------------
 
 Too many to list. Please see the
-`commit log <https://github.com/inducer/pyopencl/commits/master>`_
+`commit log <https://github.com/inducer/pyopencl/commits/main>`_
 for detailed acknowledgments.
 
 Funding

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -8,8 +8,8 @@ Installing PyOpenCL
 ^^^^^^^^^^^^^^^^^^^
 
 By far the easiest way to install PyOpenCL is to use the packages available in
-`Conda Forge <https://conda-forge.org/>`_. Conda Forge is a repository of
-community-maintained packages for the `Conda <https://conda.io/docs/>`_
+`Conda Forge <https://conda-forge.org/>`__. Conda Forge is a repository of
+community-maintained packages for the `Conda <https://conda.io/en/latest>`__
 package manager. The following instructions are aimed at Linux and macOS.
 The analogous steps for Windows should also work.
 
@@ -72,7 +72,7 @@ On Linux, Windows and macOS, you can use Oclgrind to detect memory access errors
     conda install oclgrind
 
 You are now ready to run code based on PyOpenCL, such as the `code
-examples <https://github.com/inducer/pyopencl/tree/main/examples>`_.
+examples <https://github.com/inducer/pyopencl/tree/main/examples>`__.
 
 Using vendor-supplied OpenCL drivers (mainly on Linux)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ qualified path names of the shared library providing the OpenCL driver.
 .. note::
 
     If you ran the commands above in a
-    `Conda environment <https://conda.io/docs/user-guide/tasks/manage-environments.html>`_
+    `Conda environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__
     (i.e. if the environment indicator on your command line prompt says anything other
     than ``(root)``), then you may need to use a path like the following instead:
 
@@ -116,7 +116,7 @@ As an alternative, one may manually copy ICD files from :file:`/etc/OpenCL/vendo
 e.g., :file:`$CONDA_PREFIX/etc/OpenCL/vendors`.
 
 If you are looking for more information, see `ocl-icd
-<https://github.com/OCL-dev/ocl-icd>`_ and its documentation. Ocl-icd is the
+<https://github.com/OCL-dev/ocl-icd>`__ and its documentation. Ocl-icd is the
 "ICD loader" used by PyOpenCL when installed from Conda Forge on Linux.
 It represents the code behind :file:`libOpenCL.so`.
 
@@ -127,7 +127,7 @@ On macOS, using the command::
 will make sure that the Apple provided CPU and GPU implementations are available.
 
 On Windows, the packaging of PyOpenCL for Conda Forge relies on the
-`Khronos ICD Loader <https://github.com/KhronosGroup/OpenCL-ICD-Loader>`_,
+`Khronos ICD Loader <https://github.com/KhronosGroup/OpenCL-ICD-Loader>`__,
 and it is packaged so that the OpenCL drivers that are registered in the OS
 using registry keys are automatically available.
 
@@ -136,12 +136,13 @@ Installing from PyPI wheels
 ---------------------------
 
 PyOpenCL distributes wheels for most popular OSs and Python versions.
-To check available versions please visit `PyPI page for PyOpenCL <https://pypi.org/project/pyopencl/>`__.
+To check available versions please visit `PyPI page for PyOpenCL
+<https://pypi.org/project/pyopencl/>`__.
 
 
-On Linux, the wheels come with `OCL-ICD <https://github.com/OCL-dev/ocl-icd>`__ bundled and
-configured to use any OpenCL implementation supporting the ICD interface and listed
-in :file:`/etc/OpenCL/vendors`.
+On Linux, the wheels come with `OCL-ICD <https://github.com/OCL-dev/ocl-icd>`__
+bundled and configured to use any OpenCL implementation supporting the ICD
+interface and listed in :file:`/etc/OpenCL/vendors`.
 Wheels for Windows and MacOS are built using the ICD Loader from the Khronos Group.
 
 To install, type::
@@ -149,9 +150,9 @@ To install, type::
     pip install pyopencl
 
 
-You can also install the following CPU based OpenCL implementation using pip shipped as binary
-wheels. Note that pyopencl has to be installed using a wheel for pyopencl to recognize these
-wheels.
+You can also install the following CPU based OpenCL implementation using pip
+shipped as binary wheels. Note that pyopencl has to be installed using a wheel
+for pyopencl to recognize these wheels.
 
 To install pyopencl with pocl, a CPU based implementation do::
 
@@ -177,7 +178,7 @@ Installing from source
 ----------------------
 
 Information on how to install PyOpenCL *from source* is still available on the
-`Former PyOpenCL Wiki <http://wiki.tiker.net/PyOpenCL/Installation>`_, but that should
+`Former PyOpenCL Wiki <https://wiki.tiker.net/PyOpenCL/Installation>`__, but that should
 mostly not be necessary unless you have very specific needs or would like to modify
 PyOpenCL yourself.
 
@@ -189,7 +190,7 @@ Syntax highlighting
 
 You can obtain Vim syntax highlighting for OpenCL C inlined in Python by
 checking `this file
-<https://github.com/inducer/pyopencl/blob/main/contrib/pyopencl.vim>`_.
+<https://github.com/inducer/pyopencl/blob/main/contrib/pyopencl.vim>`__.
 
 Note that the triple-quoted strings containing the source must start with
 `"""//CL// ..."""`.
@@ -290,19 +291,20 @@ other software to be turned into the corresponding :mod:`pyopencl` objects.
 User-visible Changes
 ====================
 
+Unreleased
+----------
+
+.. note::
+
+    This version is currently under development. You can get snapshots from
+    PyOpenCL's `git repository <https://github.com/inducer/pyopencl>`__.
+
 Version 2022.2
 --------------
 
 - Added :ref:`opaque-style SVM <opaque-svm>` and :class:`pyopencl.SVMPointer`.
 - Added :class:`pyopencl.tools.SVMPool`.
 - Added automatic queue-synchronized deallocation of SVM.
-
-Version 2020.3
---------------
-.. note::
-
-    This version is currently under development. You can get snapshots from
-    PyOpenCL's `git repository <https://github.com/inducer/pyopencl>`_
 
 Version 2020.2
 --------------
@@ -321,7 +323,8 @@ Version 2018.2
 Version 2018.1
 --------------
 
-* Introduce *eliminate_empty_output_lists* argument of :class:`pyopencl.algorithm.ListOfListsBuilder`.
+* Introduce *eliminate_empty_output_lists* argument of
+  :class:`pyopencl.algorithm.ListOfListsBuilder`.
 * Many bug fixes.
 
 Version 2017.2
@@ -457,7 +460,7 @@ Version 2013.1
 
     The addition of :meth:`pyopencl.array.Array.__getitem__` has an unintended
     consequence due to `numpy bug 3375
-    <https://github.com/numpy/numpy/issues/3375>`_.  For instance, this
+    <https://github.com/numpy/numpy/issues/3375>`__.  For instance, this
     expression::
 
         numpy.float32(5) * some_pyopencl_array
@@ -496,8 +499,8 @@ Version 2011.2
 * Add :func:`pyopencl.image_from_array`.
 * IMPORTANT BUGFIX: Kernel caching was broken for all the 2011.1.x releases, with
   severe consequences on the execution time of :class:`pyopencl.array.Array`
-  operations.
-  Henrik Andresen at a `PyOpenCL workshop at DTU <http://gpulab.imm.dtu.dk/courses.html>`_
+  operations. Henrik Andresen at a
+  `PyOpenCL workshop at DTU <http://gpulab.compute.dtu.dk/courses.html>`__
   first noticed the strange timings.
 * All comparable PyOpenCL objects are now also hashable.
 * Add ``pyopencl.tools.context_dependent_memoize`` to the documented
@@ -565,14 +568,14 @@ Version 0.92
 
 * Add support for OpenCL 1.1.
 * Add support for the
-  `cl_khr_gl_sharing <ghttp://www.khronos.org/registry/cl/extensions/khr/cl_khr_gl_sharing.txt>`_
+  `cl_khr_gl_sharing <https://registry.khronos.org/OpenCL/sdk/1.2/docs/man/xhtml/cl_khr_gl_sharing.html>`__
   extension, leading to working GL interoperability.
 * Add :meth:`pyopencl.Kernel.set_args`.
 * The call signature of :meth:`pyopencl.Kernel.__call__` changed to
   emphasize the importance of *local_size*.
 * Add :meth:`pyopencl.Kernel.set_scalar_arg_dtypes`.
 * Add support for the
-  `cl_nv_device_attribute_query <https://registry.khronos.org/OpenCL/extensions/nv/cl_nv_device_attribute_query.txt>`_
+  `cl_nv_device_attribute_query <https://registry.khronos.org/OpenCL/extensions/nv/cl_nv_device_attribute_query.txt>`__
   extension.
 * Add :meth:`pyopencl.array.Array` and related functionality.
 * Make build not depend on Boost C++.
@@ -691,7 +694,7 @@ Frequently Asked Questions
 ==========================
 
 The FAQ is maintained collaboratively on the
-`Wiki FAQ page <http://wiki.tiker.net/PyOpenCL/FrequentlyAskedQuestions>`_.
+`Wiki FAQ page <https://wiki.tiker.net/PyOpenCL/FrequentlyAskedQuestions>`__.
 
 Citing PyOpenCL
 ===============
@@ -700,7 +703,7 @@ We are not asking you to gratuitously cite PyOpenCL in work that is otherwise
 unrelated to software. That said, if you do discuss some of the development
 aspects of your code and would like to highlight a few of the ideas behind
 PyOpenCL, feel free to cite `this article
-<http://dx.doi.org/10.1016/j.parco.2011.09.001>`_:
+<https://doi.org/10.1016/j.parco.2011.09.001>`__:
 
     Andreas Klöckner, Nicolas Pinto, Yunsup Lee, Bryan Catanzaro, Paul Ivanov,
     Ahmed Fasih, PyCUDA and PyOpenCL: A scripting-based approach to GPU
@@ -733,7 +736,7 @@ Contributors
 ------------
 
 Too many to list. Please see the
-`commit log <https://github.com/inducer/pyopencl/commits/main>`_
+`commit log <https://github.com/inducer/pyopencl/commits/main>`__
 for detailed acknowledgments.
 
 Funding
@@ -774,51 +777,51 @@ OpenCL Specification
 --------------------
 .. c:type:: cl_platform_id
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#opencl-platform-layer>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#opencl-platform-layer>`__.
 
 .. c:type:: cl_device_id
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#opencl-platform-layer>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#opencl-platform-layer>`__.
 
 .. c:type:: cl_context
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_contexts>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_contexts>`__.
 
 .. c:type:: cl_command_queue
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_command_queues>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_command_queues>`__.
 
 .. c:type:: cl_mem
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_memory_objects>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_memory_objects>`__.
 
 .. c:type:: cl_program
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_program_objects>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_program_objects>`__.
 
 .. c:type:: cl_kernel
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_kernel_objects>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_kernel_objects>`__.
 
 .. c:type:: cl_sampler
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_sampler_objects>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_sampler_objects>`__.
 
 .. c:type:: cl_event
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#event-objects>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#event-objects>`__.
 
 .. c:function:: void clCreateCommandQueueWithProperties()
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clCreateCommandQueueWithProperties>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clCreateCommandQueueWithProperties>`__.
 
 .. c:function:: void clCreateSamplerWithProperties()
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clCreateSamplerWithProperties>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clCreateSamplerWithProperties>`__.
 
 .. c:function:: void clCreatePipe()
 
-   See the  `CL specification <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clCreatePipe>`__.
+   See the `CL specification <https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clCreatePipe>`__.
 
 Internal Types
 --------------

--- a/doc/runtime_memory.rst
+++ b/doc/runtime_memory.rst
@@ -58,7 +58,7 @@ Buffer
     .. note::
 
         Python also defines a type of `buffer object
-        <https://docs.python.org/3.4/c-api/buffer.html>`_,
+        <https://docs.python.org/3/c-api/buffer.html>`__,
         and PyOpenCL interacts with those, too, as the host-side
         target of :func:`enqueue_copy`. Make sure to always be
         clear on whether a :class:`Buffer` or a Python buffer

--- a/doc/runtime_platform.rst
+++ b/doc/runtime_platform.rst
@@ -126,7 +126,8 @@ Context
         CL drivers that support the OpenCL ICD. If you want similar,
         just-give-me-a-context-already behavior, we recommend
         :func:`create_some_context`. See, e.g. this
-        `explanation by AMD <http://developer.amd.com/support/KnowledgeBase/Lists/KnowledgeBase/DispForm.aspx?ID=71>`_.
+        `explanation by AMD
+        <https://web.archive.org/web/20101114195033/https://developer.amd.com/support/KnowledgeBase/Lists/KnowledgeBase/DispForm.aspx?ID=71>`_.
 
     .. note::
 

--- a/doc/runtime_platform.rst
+++ b/doc/runtime_platform.rst
@@ -127,7 +127,7 @@ Context
         just-give-me-a-context-already behavior, we recommend
         :func:`create_some_context`. See, e.g. this
         `explanation by AMD
-        <https://web.archive.org/web/20101114195033/https://developer.amd.com/support/KnowledgeBase/Lists/KnowledgeBase/DispForm.aspx?ID=71>`_.
+        <https://web.archive.org/web/20101114195033/https://developer.amd.com/support/KnowledgeBase/Lists/KnowledgeBase/DispForm.aspx?ID=71>`__.
 
     .. note::
 

--- a/doc/runtime_program.rst
+++ b/doc/runtime_program.rst
@@ -39,7 +39,7 @@ Program
 
     *binaries* must contain one binary for each entry in *devices*.
     If *src* is a :class:`bytes` object starting with a valid `SPIR-V
-    <https://www.khronos.org/spir>`_ magic number, it will be handed
+    <https://www.khronos.org/spir>`__ magic number, it will be handed
     off to the OpenCL implementation as such, rather than as OpenCL C source
     code. (SPIR-V support requires OpenCL 2.1.)
 
@@ -273,7 +273,7 @@ Kernel
 
             A solution involving implicit locks was discussed and decided against on the
             mailing list in `October 2012
-            <https://lists.tiker.net/pipermail/pyopencl/2012-October/001311.html>`_.
+            <https://lists.tiker.net/pipermail/pyopencl/2012-October/001311.html>`__.
 
         .. versionchanged:: 0.92
 

--- a/doc/runtime_program.rst
+++ b/doc/runtime_program.rst
@@ -273,7 +273,7 @@ Kernel
 
             A solution involving implicit locks was discussed and decided against on the
             mailing list in `October 2012
-            <http://lists.tiker.net/pipermail/pyopencl/2012-October/001311.html>`_.
+            <https://lists.tiker.net/pipermail/pyopencl/2012-October/001311.html>`_.
 
         .. versionchanged:: 0.92
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1767,7 +1767,7 @@ def enqueue_copy(queue, dest, src, **kwargs):
         Two types of 'buffer' occur in the arguments to this function,
         :class:`Buffer` and 'host-side buffers'. The latter are
         defined by Python and commonly called `buffer objects
-        <https://docs.python.org/3.4/c-api/buffer.html>`_. :mod:`numpy`
+        <https://docs.python.org/3/c-api/buffer.html>`__. :mod:`numpy`
         arrays are a very common example.
         Make sure to always be clear on whether a :class:`Buffer` or a
         Python buffer object is needed.

--- a/pyopencl/algorithm.py
+++ b/pyopencl/algorithm.py
@@ -426,7 +426,7 @@ RADIX_SORT_OUTPUT_STMT_TPL = Template(r"""//CL//
 # {{{ driver
 
 class RadixSort:
-    """Provides a general `radix sort <https://en.wikipedia.org/wiki/Radix_sort>`_
+    """Provides a general `radix sort <https://en.wikipedia.org/wiki/Radix_sort>`__
     on the compute device.
 
     .. seealso:: :class:`pyopencl.bitonic_sort.BitonicSort`

--- a/pyopencl/characterize/__init__.py
+++ b/pyopencl/characterize/__init__.py
@@ -376,7 +376,7 @@ def _check_for_pocl_arg_count_bug(
 
 def has_struct_arg_count_bug(dev, ctx=None):
     """Checks whether the device is expected to have the
-    `argument counting bug <https://github.com/pocl/pocl/issues/197>`_.
+    `argument counting bug <https://github.com/pocl/pocl/issues/197>`__.
     """
 
     if dev.platform.name == "Apple" and dev.type & cl.device_type.CPU:

--- a/pyopencl/clrandom.py
+++ b/pyopencl/clrandom.py
@@ -25,17 +25,17 @@ THE SOFTWARE.
 
 __doc__ = """
 PyOpenCL now includes and uses some of the `Random123 random number generators
-<https://www.deshawresearch.com/resources_random123.html>`_ by D.E. Shaw
-Research.  In addition to being usable through the convenience functions above,
+<https://www.deshawresearch.com/resources.html>`__ by D.E. Shaw
+Research. In addition to being usable through the convenience functions above,
 they are available in any piece of code compiled through PyOpenCL by::
 
     #include <pyopencl-random123/philox.cl>
     #include <pyopencl-random123/threefry.cl>
 
 See the `Philox source
-<https://github.com/inducer/pyopencl/blob/master/pyopencl/cl/pyopencl-random123/philox.cl>`_
+<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-random123/philox.cl>`_
 and the `Threefry source
-<https://github.com/inducer/pyopencl/blob/master/pyopencl/cl/pyopencl-random123/threefry.cl>`_
+<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-random123/threefry.cl>`_
 for some documentation if you're planning on using Random123 directly.
 
 .. note::

--- a/pyopencl/clrandom.py
+++ b/pyopencl/clrandom.py
@@ -40,8 +40,8 @@ for some documentation if you're planning on using Random123 directly.
 
 .. note::
 
-    PyOpenCL previously had documented support for the `RANLUXCL random number
-    generator <https://bitbucket.org/ivarun/ranluxcl/>`_ by Ivar Ursin
+    PyOpenCL previously had documented support for the RANLUXCL random number
+    generator (``https://bitbucket.org/ivarun/ranluxcl``) by Ivar Ursin
     Nikolaisen. This support is now deprecated because of the general slowness
     of these generators and will be removed from PyOpenCL in the 2018.x series.
     All users are encouraged to switch to one of the Random123 generators,

--- a/pyopencl/clrandom.py
+++ b/pyopencl/clrandom.py
@@ -33,9 +33,9 @@ they are available in any piece of code compiled through PyOpenCL by::
     #include <pyopencl-random123/threefry.cl>
 
 See the `Philox source
-<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-random123/philox.cl>`_
+<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-random123/philox.cl>`__
 and the `Threefry source
-<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-random123/threefry.cl>`_
+<https://github.com/inducer/pyopencl/blob/main/pyopencl/cl/pyopencl-random123/threefry.cl>`__
 for some documentation if you're planning on using Random123 directly.
 
 .. note::

--- a/pyopencl/scan.py
+++ b/pyopencl/scan.py
@@ -11,7 +11,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Derived from code within the Thrust project, https://github.com/thrust/thrust/
+Derived from code within the Thrust project, https://github.com/NVIDIA/thrust
 """
 
 from abc import ABC, abstractmethod

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -699,10 +699,10 @@ def pytest_generate_tests_for_pyopencl(metafunc):
         from pyopencl.tools import pytest_generate_tests_for_pyopencl
                 as pytest_generate_tests
 
-    in your `pytest <http://pytest.org>`_ test scripts allows you to use the
-    arguments *ctx_factory*, *device*, or *platform* in your test functions,
-    and they will automatically be run for each OpenCL device/platform in the
-    system, as appropriate.
+    in your `pytest <https://docs.pytest.org/en/latest/>`__ test scripts allows
+    you to use the arguments *ctx_factory*, *device*, or *platform* in your test
+    functions, and they will automatically be run for each OpenCL device/platform
+    in the system, as appropriate.
 
     The following two environment variabls is also supported to control
     device/platform choice::


### PR DESCRIPTION
Found when getting paranoid in #650 using
```
make linkcheck SPHINXOPTS="-W --keep-going -n" 
```
Mostly fixes dead links, changes redirects and uses `https` hopefully everywhere. These are only links that show up in the docs, not ones that show up in comments and stuff.