### PR TITLE
docs: update intersphinx mapping from deprecated variant

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ version = ".".join(str(x) for x in ver_dic["VERSION"])
 release = ver_dic["VERSION_TEXT"]
 
 intersphinx_mapping = {
-    "https://docs.python.org/dev": None,
-    "https://numpy.org/doc/stable/": None,
-    "https://docs.makotemplates.org/en/latest/": None,
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "mako": ("https://docs.makotemplates.org/en/latest", None),
 }

--- a/examples/median-filter.py
+++ b/examples/median-filter.py
@@ -1,10 +1,12 @@
-import pyopencl as cl
 import numpy as np
 from imageio import imread, imsave
+
+import pyopencl as cl
 
 # Read in image
 img = imread("noisyImage.jpg").astype(np.float32)
 print(img.shape)
+
 img = np.mean(img, axis=2)
 print(img.shape)
 
@@ -93,4 +95,4 @@ result = np.empty_like(img)
 cl.enqueue_copy(queue, result, result_g)
 
 # Show the blurred image
-imsave("medianFilter-OpenCL.jpg", result)
+imsave("medianFilter-OpenCL.jpg", result, mode="RGB")


### PR DESCRIPTION
This was deprecated in Sphinx 6.2 and is now throwing some verbose warnings
https://www.sphinx-doc.org/en/master/changes.html#id7