### PR TITLE
Run flake8 without an env on Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
             run: |
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0
-                build_py_project_in_conda_env
                 install_and_run_flake8 "$(get_proj_name)" examples/*.py test/*.py
 
     pylint:


### PR DESCRIPTION
In a way, this addresses
https://github.com/zheller/flake8-quotes/issues/117, since it forces the Python that runs flake8 onto 'oldest supported', currently 3.8.