### PR TITLE
only warn about argument sizes on Nvidia GPUs

### DIFF
--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -342,9 +342,8 @@ def _check_arg_size(function_name, num_cl_args, arg_types, devs):
             # the device limit have been observed only on such devices.
             continue
 
-        dev_limit = _get_max_parameter_size(dev)
-
         dev_ptr_size = int(dev.address_bits / 8)
+        dev_limit = _get_max_parameter_size(dev)
 
         total_arg_size = 0
 

--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -336,12 +336,13 @@ def _check_arg_size(function_name, num_cl_args, arg_types, devs):
     """Check whether argument sizes exceed the OpenCL device limit."""
 
     for dev in devs:
-        dev_limit = _get_max_parameter_size(dev)
-        if dev_limit != 4352:
-            # Only warn if the limit is the default value for Nvidia GPUs
-            # (4352 bytes), because failures have been observed only on such
-            # devices.
+        from pyopencl.characterize import nv_compute_capability
+        if nv_compute_capability(dev) is None:
+            # Only warn on Nvidia GPUs, because actual failures related to
+            # the device limit have been observed only on such devices.
             continue
+
+        dev_limit = _get_max_parameter_size(dev)
 
         dev_ptr_size = int(dev.address_bits / 8)
 

--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -348,12 +348,9 @@ def _check_arg_size(function_name, num_cl_args, arg_types, devs):
 
         total_arg_size = 0
 
-        is_estimate = False
-
         if arg_types:
             for arg_type in arg_types:
                 if arg_type is None:
-                    is_estimate = True
                     total_arg_size += dev_ptr_size
                 elif isinstance(arg_type, VectorArg):
                     total_arg_size += dev_ptr_size
@@ -361,22 +358,12 @@ def _check_arg_size(function_name, num_cl_args, arg_types, devs):
                     total_arg_size += np.dtype(arg_type).itemsize
         else:
             # Estimate that each argument has the size of a pointer on average
-            is_estimate = True
             total_arg_size = dev_ptr_size * num_cl_args
 
         if total_arg_size > dev_limit:
             from warnings import warn
             warn(f"Kernel '{function_name}' has {num_cl_args} arguments with "
                 f"a total size of {total_arg_size} bytes, which is higher than "
-                f"the limit of {dev_limit} bytes on {dev}. This might "
-                "lead to compilation errors, especially on GPU devices.",
-                stacklevel=3)
-        elif is_estimate and total_arg_size >= dev_limit * 0.75:
-            # Since total_arg_size is just an estimate, also warn in case we are
-            # just below the actual limit.
-            from warnings import warn
-            warn(f"Kernel '{function_name}' has {num_cl_args} arguments with "
-                f"a total size of {total_arg_size} bytes, which approaches "
                 f"the limit of {dev_limit} bytes on {dev}. This might "
                 "lead to compilation errors, especially on GPU devices.",
                 stacklevel=3)


### PR DESCRIPTION
In our experience, only Nvidia GPUs actually have compilation errors when the argument size is too large; most other CL devices have artificially low limits (usually 1024 bytes, roughly corresponding to the 127 arguments requirement of the [C standard](https://c0x.shape-of-code.com/5.2.4.1.html)), but compile and run much larger argument sizes fine, thus leading to lots of spurious warnings on any non-Nvidia device.

_Please squash_