### PR TITLE
Port to np.random.Generator

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -3,8 +3,9 @@
 import numpy as np
 import pyopencl as cl
 
-a_np = np.random.rand(50000).astype(np.float32)
-b_np = np.random.rand(50000).astype(np.float32)
+rng = np.random.default_rng()
+a_np = rng.random(50000, dtype=np.float32)
+b_np = rng.random(50000, dtype=np.float32)
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
@@ -30,6 +31,7 @@ res_np = np.empty_like(a_np)
 cl.enqueue_copy(queue, res_np, res_g)
 
 # Check on CPU with Numpy:
-print(res_np - (a_np + b_np))
-print(np.linalg.norm(res_np - (a_np + b_np)))
+error_np = res_np - (a_np + b_np)
+print(f"Error:\n{error_np}")
+print(f"Norm: {np.linalg.norm(error_np):.16e}")
 assert np.allclose(res_np, a_np + b_np)

--- a/examples/demo_array.py
+++ b/examples/demo_array.py
@@ -1,10 +1,12 @@
-import pyopencl as cl
-import pyopencl.array as cl_array
-import numpy
+import numpy as np
 import numpy.linalg as la
 
-a = numpy.random.rand(50000).astype(numpy.float32)
-b = numpy.random.rand(50000).astype(numpy.float32)
+import pyopencl as cl
+import pyopencl.array as cl_array
+
+rng = np.random.default_rng()
+a = rng.random(50000, dtype=np.float32)
+b = rng.random(50000, dtype=np.float32)
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
@@ -26,3 +28,4 @@ knl = prg.sum  # Use this Kernel object for repeated calls
 knl(queue, a.shape, None, a_dev.data, b_dev.data, dest_dev.data)
 
 print(la.norm((dest_dev - (a_dev+b_dev)).get()))
+assert np.allclose(dest_dev.get(), (a_dev + b_dev).get())

--- a/examples/demo_array_svm.py
+++ b/examples/demo_array_svm.py
@@ -1,12 +1,14 @@
+import numpy as np
+
 import pyopencl as cl
 import pyopencl.array as cl_array
 from pyopencl.tools import SVMAllocator, SVMPool
-import numpy as np
 
 n = 50000
-a = np.random.rand(n).astype(np.float32)
-b = np.random.rand(n).astype(np.float32)
 
+rng = np.random.default_rng()
+a = rng.random(n, dtype=np.float32)
+b = rng.random(n, dtype=np.float32)
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
@@ -30,4 +32,5 @@ prg = cl.Program(ctx, """
 knl = prg.sum
 knl(queue, a.shape, None, a_dev.data, b_dev.data, dest_dev.data)
 
-np.testing.assert_allclose(dest_dev.get(), (a_dev+b_dev).get())
+print(np.linalg.norm((dest_dev - (a_dev + b_dev)).get()))
+assert np.allclose(dest_dev.get(), (a_dev + b_dev).get())

--- a/examples/demo_elementwise.py
+++ b/examples/demo_elementwise.py
@@ -1,13 +1,14 @@
-#!/usr/bin/env python
-
 import numpy as np
+
 import pyopencl as cl
 import pyopencl.array
 from pyopencl.elementwise import ElementwiseKernel
 
 n = 10
-a_np = np.random.randn(n).astype(np.float32)
-b_np = np.random.randn(n).astype(np.float32)
+
+rng = np.random.default_rng()
+a_np = rng.random(n, dtype=np.float32)
+b_np = rng.random(n, dtype=np.float32)
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)

--- a/examples/demo_elementwise_complex.py
+++ b/examples/demo_elementwise_complex.py
@@ -1,18 +1,23 @@
+import numpy as np
+import numpy.linalg as la
+
 import pyopencl as cl
 import pyopencl.array as cl_array
-import numpy
-import numpy.linalg as la
+from pyopencl.elementwise import ElementwiseKernel
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
 
 n = 10
-a_gpu = cl_array.to_device(queue,
-        (numpy.random.randn(n) + 1j*numpy.random.randn(n)).astype(numpy.complex64))
-b_gpu = cl_array.to_device(queue,
-        (numpy.random.randn(n) + 1j*numpy.random.randn(n)).astype(numpy.complex64))
 
-from pyopencl.elementwise import ElementwiseKernel
+rng = np.random.default_rng()
+a_gpu = cl_array.to_device(queue,
+        rng.standard_normal(n, dtype=np.float32)
+        + 1j*rng.standard_normal(n, dtype=np.float32))
+b_gpu = cl_array.to_device(queue,
+        rng.standard_normal(n, dtype=np.float32)
+        + 1j*rng.standard_normal(n, dtype=np.float32))
+
 complex_prod = ElementwiseKernel(ctx,
         "float a, "
         "cfloat_t *x, "
@@ -39,7 +44,7 @@ real_part = ElementwiseKernel(ctx,
 c_gpu = cl_array.empty_like(a_gpu)
 complex_prod(5, a_gpu, b_gpu, c_gpu)
 
-c_gpu_real = cl_array.empty(queue, len(a_gpu), dtype=numpy.float32)
+c_gpu_real = cl_array.empty(queue, len(a_gpu), dtype=np.float32)
 real_part(c_gpu, c_gpu_real)
 print(c_gpu.get().real - c_gpu_real.get())
 

--- a/examples/demo_meta_codepy.py
+++ b/examples/demo_meta_codepy.py
@@ -1,29 +1,28 @@
-import pyopencl as cl
-import numpy
+import numpy as np
 import numpy.linalg as la
+from cgen import (POD, Assign, Block, Const, FunctionBody, FunctionDeclaration,
+                  Initializer, Module, Pointer, Value)
+from cgen.opencl import CLGlobal, CLKernel, CLRequiredWorkGroupSize
+
+import pyopencl as cl
 
 local_size = 256
 thread_strides = 32
 macroblock_count = 33
-dtype = numpy.float32
+dtype = np.float32
 total_size = local_size*thread_strides*macroblock_count
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
 
-a = numpy.random.randn(total_size).astype(dtype)
-b = numpy.random.randn(total_size).astype(dtype)
+rng = np.random.default_rng()
+a = rng.standard_normal(total_size, dtype=dtype)
+b = rng.standard_normal(total_size, dtype=dtype)
 
 mf = cl.mem_flags
 a_buf = cl.Buffer(ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=a)
 b_buf = cl.Buffer(ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=b)
 c_buf = cl.Buffer(ctx, mf.WRITE_ONLY, b.nbytes)
-
-from cgen import FunctionBody, \
-        FunctionDeclaration, POD, Value, \
-        Pointer, Module, Block, Initializer, Assign, Const
-from cgen.opencl import CLKernel, CLGlobal, \
-        CLRequiredWorkGroupSize
 
 mod = Module([
     FunctionBody(
@@ -33,7 +32,7 @@ mod = Module([
             arg_decls=[CLGlobal(Pointer(Const(POD(dtype, name))))
                 for name in ["tgt", "op1", "op2"]]))),
         Block([
-            Initializer(POD(numpy.int32, "idx"),
+            Initializer(POD(np.int32, "idx"),
                 "get_local_id(0) + %d * get_group_id(0)"
                 % (local_size*thread_strides))
             ]+[
@@ -49,7 +48,7 @@ knl = cl.Program(ctx, str(mod)).build().add
 knl(queue, (local_size*macroblock_count,), (local_size,),
         c_buf, a_buf, b_buf)
 
-c = numpy.empty_like(a)
+c = np.empty_like(a)
 cl.enqueue_copy(queue, c, c_buf).wait()
 
 assert la.norm(c-(a+b)) == 0

--- a/examples/demo_meta_template.py
+++ b/examples/demo_meta_template.py
@@ -1,25 +1,27 @@
-import pyopencl as cl
-import numpy
+import numpy as np
 import numpy.linalg as la
+
+from mako.template import Template
+
+import pyopencl as cl
 
 local_size = 256
 thread_strides = 32
 macroblock_count = 33
-dtype = numpy.float32
+dtype = np.float32
 total_size = local_size*thread_strides*macroblock_count
 
 ctx = cl.create_some_context()
 queue = cl.CommandQueue(ctx)
 
-a = numpy.random.randn(total_size).astype(dtype)
-b = numpy.random.randn(total_size).astype(dtype)
+rng = np.random.default_rng()
+a = rng.standard_normal(total_size, dtype=dtype)
+b = rng.standard_normal(total_size, dtype=dtype)
 
 mf = cl.mem_flags
 a_buf = cl.Buffer(ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=a)
 b_buf = cl.Buffer(ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=b)
 c_buf = cl.Buffer(ctx, mf.WRITE_ONLY, b.nbytes)
-
-from mako.template import Template
 
 tpl = Template("""
     __kernel void add(
@@ -47,7 +49,7 @@ knl = cl.Program(ctx, str(rendered_tpl)).build().add
 knl(queue, (local_size*macroblock_count,), (local_size,),
         c_buf, a_buf, b_buf)
 
-c = numpy.empty_like(a)
+c = np.empty_like(a)
 cl.enqueue_copy(queue, c, c_buf).wait()
 
 assert la.norm(c-(a+b)) == 0

--- a/examples/n-body.py
+++ b/examples/n-body.py
@@ -17,10 +17,11 @@ http://mathema.tician.de/software/pyopencl
 import getopt
 import sys
 import time
+
 import numpy as np
+
 import pyopencl as cl
 import pyopencl.array
-from numpy.random import randint as nprnd
 
 
 def DictionariesAPI():
@@ -871,8 +872,9 @@ if __name__ == "__main__":
 
     # Set particles to RNG points
     if InitialRandom:
-        seed_w = np.uint32(nprnd(2 ** 32))
-        seed_z = np.uint32(nprnd(2 ** 32))
+        rng = np.random.default_rng()
+        seed_w = np.uint32(rng.integers(2 ** 32))
+        seed_z = np.uint32(rng.integers(2 ** 32))
     else:
         seed_w = np.uint32(19710211)
         seed_z = np.uint32(20081010)

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -1428,8 +1428,9 @@ def test_capture_call(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
 
-    a_np = np.random.rand(500).astype(np.float32)
-    b_np = np.random.rand(500).astype(np.float32)
+    rng = np.random.default_rng()
+    a_np = rng.random(500, dtype=np.float32)
+    b_np = rng.random(500, dtype=np.float32)
 
     ctx = cl.create_some_context()
     queue = cl.CommandQueue(ctx)


### PR DESCRIPTION
This ports the examples to `np.random.Generator` to fix some deprecation warnings in numpy 2.0.

I also updated `gl_particle_animation` to not do `from GL import *` because it was giving a lot of pylint warnings. I couldn't run it though because it raised
```
AttributeError: type object 'pyopencl._cl.context_properties' has no attribute 'GL_CONTEXT_KHR'
``` 
Not quite sure what's missing on my system (I compiled with `CL_ENABLE_GL` and whatever else I could find).