### PR TITLE
Port deprecated pkg_resources to importlib.resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
                 . ci-support-v0
                 ./configure.py --cl-use-shipped-ext
                 build_py_project_in_conda_env
-                python -m pip install mypy types-setuptools
+
+                python -m pip install mypy importlib-resources
                 python -m mypy --show-error-codes pyopencl test
 
     pytest:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,7 +216,7 @@ Pylint:
 
 Mypy:
   script: |
-    export EXTRA_INSTALL="pybind11 numpy mako mypy types-setuptools"
+    export EXTRA_INSTALL="pybind11 numpy mako mypy importlib-resources"
 
     curl -L -O https://tiker.net/ci-support-v0
     . ci-support-v0

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -279,21 +279,21 @@ def compiler_output(text):
 
 # {{{ find pyopencl shipped source code
 
-def _find_pyopencl_include_path():
+def _find_pyopencl_include_path() -> str:
     from os.path import join, abspath, dirname, exists
-    try:
-        # Try to find the include path in the same directory as this file
-        include_path = join(abspath(dirname(__file__)), "cl")
+
+    # Try to find the include path in the same directory as this file
+    include_path = join(abspath(dirname(__file__)), "cl")
+    if not exists(include_path):
+        try:
+            # NOTE: only available in Python >=3.9
+            from importlib.resources import files
+        except ImportError:
+            from importlib_resources import files
+
+        include_path = str(files("pyopencl") / "cl")
         if not exists(include_path):
-            raise OSError("unable to find pyopencl include path")
-    except Exception:
-        # Try to find the resource with pkg_resources (the recommended
-        # setuptools approach). This is very slow.
-        from pkg_resources import Requirement, resource_filename
-        include_path = resource_filename(
-                Requirement.parse("pyopencl"), "pyopencl/cl")
-        if not exists(include_path):
-            raise OSError("unable to find pyopencl include path")
+            raise OSError("Unable to find PyOpenCL include path")
 
     # Quote the path if it contains a space and is not quoted already.
     # See https://github.com/inducer/pyopencl/issues/250 for discussion.
@@ -310,9 +310,6 @@ def _find_pyopencl_include_path():
 def _split_options_if_necessary(options):
     if isinstance(options, str):
         import shlex
-        # shlex.split takes unicode (py3 str) on py3
-        if isinstance(options, bytes):
-            options = options.decode("utf-8")
 
         options = shlex.split(options)
 

--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ def main():
                 "numpy",
                 "pytools>=2021.2.7",
                 "platformdirs>=2.2.0",
+                "importlib-resources; python_version<'3.9'",
                 # "Mako>=0.3.6",
                 ],
             extras_require={


### PR DESCRIPTION
This ports from `pkg_resources` to the newer `importlib.resources` as described in
https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename
and removes an implicit runtime dependency on `setuptools`. It also needs a newer version of `importlib.resources` because the pre 3.9 version didn't support directories and `pyopencl/cl` is a directory in our case.

Not sure how to test this because the include path is already in the first path it looks at: `join(abspath(dirname(__file__)), "cl")`. I checked that the `pkg_resources` result is the same on my system. Does the CI test that at all?