### PR TITLE
invoker, scan: honor PYOPENCL_NO_CACHE for writing

### DIFF
--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -373,7 +373,8 @@ def _check_arg_size(function_name, num_cl_args, arg_types, devs):
 # }}}
 
 
-invoker_cache = WriteOncePersistentDict(
+if not cl._PYOPENCL_NO_CACHE:
+    invoker_cache = WriteOncePersistentDict(
         "pyopencl-invoker-cache-v41",
         key_builder=_NumpyTypesKeyBuilder(),
         in_mem_cache_size=0)
@@ -400,7 +401,8 @@ def generate_enqueue_and_set_args(function_name,
 
     if not from_cache:
         pmod, enqueue_name = _generate_enqueue_and_set_args_module(*cache_key)
-        invoker_cache.store_if_not_present(cache_key, (pmod, enqueue_name))
+        if not cl._PYOPENCL_NO_CACHE:
+            invoker_cache.store_if_not_present(cache_key, (pmod, enqueue_name))
 
     return (
             pmod.mod_globals[enqueue_name],

--- a/pyopencl/scan.py
+++ b/pyopencl/scan.py
@@ -1141,7 +1141,8 @@ class GenericScanKernelBase(ABC):
         pass
 
 
-generic_scan_kernel_cache = WriteOncePersistentDict(
+if not cl._PYOPENCL_NO_CACHE:
+    generic_scan_kernel_cache = WriteOncePersistentDict(
         "pyopencl-generated-scan-kernel-cache-v1",
         key_builder=_NumpyTypesKeyBuilder(),
         in_mem_cache_size=0)
@@ -1199,7 +1200,8 @@ class GenericScanKernel(GenericScanKernelBase):
                       self.second_level_scan_gen_info,
                       self.final_update_gen_info)
 
-            generic_scan_kernel_cache.store_if_not_present(cache_key, result)
+            if not cl._PYOPENCL_NO_CACHE:
+                generic_scan_kernel_cache.store_if_not_present(cache_key, result)
 
         # Build the kernels.
         self.first_level_scan_info = self.first_level_scan_gen_info.build(


### PR DESCRIPTION
(found while looking at #731)

With this PR, no Pyopencl cache is created when `PYOPENCL_NO_CACHE` is set.