### PR TITLE
PYOPENCL_NO_CACHE: allow re-enabling the cache with False value

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,4 +21,5 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "mako": ("https://docs.makotemplates.org/en/latest", None),
+    "pytools": ("https://documen.tician.de/pytools", None),
 }

--- a/doc/runtime_program.rst
+++ b/doc/runtime_program.rst
@@ -15,10 +15,10 @@ Program
     constructed with source. (It will depend on the ICD in use how much
     compilation work is saved by this.)
     By setting the environment variable :envvar:`PYOPENCL_NO_CACHE` to any
-    non-empty value, this caching is suppressed. No additional in-memory
-    caching is performed. To retain the compiled version of a kernel
-    in memory, simply retain the :class:`Program` and/or :class:`Kernel`
-    objects.
+    string that :func:`pytools.strtobool` evaluates as ``True``, this caching
+    is suppressed. No additional in-memory caching is performed. To retain the
+    compiled version of a kernel in memory, simply retain the :class:`Program`
+    and/or :class:`Kernel` objects.
 
     PyOpenCL will also cache "invokers", which are short snippets of Python
     that are generated to accelerate passing arguments to and enqueuing
@@ -101,8 +101,8 @@ Program
         Instead, either use the (recommended, stateless) calling interface::
 
             sum_knl = prg.sum
-            sum_knl(queue, a_np.shape, None, a_g, b_g, res_g)    
-            
+            sum_knl(queue, a_np.shape, None, a_g, b_g, res_g)
+
         or the long, stateful way around, if you prefer::
 
             sum_knl.set_args(a_g, b_g, res_g)

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -359,7 +359,8 @@ def _options_to_bytestring(options):
 
 # {{{ Program (wrapper around _Program, adds caching support)
 
-_PYOPENCL_NO_CACHE: bool = "PYOPENCL_NO_CACHE" in os.environ
+from pytools import strtobool
+_PYOPENCL_NO_CACHE = strtobool(os.environ.get("PYOPENCL_NO_CACHE", "false"))
 
 _DEFAULT_BUILD_OPTIONS: List[str] = []
 _DEFAULT_INCLUDE_OPTIONS: List[str] = ["-I", _find_pyopencl_include_path()]

--- a/pyopencl/cache.py
+++ b/pyopencl/cache.py
@@ -189,7 +189,7 @@ def get_dependencies(src, include_path):
                     finally:
                         src_file.close()
 
-                    # jrevent infinite recursion if some header file appears to
+                    # prevent infinite recursion if some header file appears to
                     # include itself
                     result[included_file_name] = None
 

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ def main():
             python_requires="~=3.8",
             install_requires=[
                 "numpy",
-                "pytools>=2021.2.7",
+                "pytools>=2022.1.13",
                 "platformdirs>=2.2.0",
                 "importlib-resources; python_version<'3.9'",
                 # "Mako>=0.3.6",


### PR DESCRIPTION
(could do the same for `LOOPY_NO_CACHE`)

Currently, `PYOPENCL_NO_CACHE` set to any value will disable the cache. This can be confusing to users (who sometimes set `PYOPENCL_NO_CACHE=0` in an attempt to re-enable the cache), and is in contrast to other software packages (including CUDA and pocl) that allow setting a specific environment variable value to enable or disable a cache.