### PR TITLE
Work around spurious size warnings

### DIFF
--- a/src/wrap_cl.hpp
+++ b/src/wrap_cl.hpp
@@ -3884,7 +3884,7 @@ namespace pyopencl
     PYOPENCL_GET_SVM_SIZE(src);
     PYOPENCL_GET_SVM_SIZE(dst);
 
-    size_t size;
+    size_t size = 0;
     bool have_size = false;
 
     if (src_has_size)
@@ -3965,7 +3965,7 @@ namespace pyopencl
 
     PYOPENCL_GET_SVM_SIZE(dst);
 
-    size_t size;
+    size_t size = 0;
     bool have_size = false;
     if (dst_has_size)
     {
@@ -4020,7 +4020,7 @@ namespace pyopencl
 
     PYOPENCL_GET_SVM_SIZE(svm);
 
-    size_t size;
+    size_t size = 0;
     bool have_size = false;
     if (svm_has_size)
     {


### PR DESCRIPTION
Avoids warnings of the type:

```
  src/wrap_cl.hpp: In function ‘pyopencl::event* pyopencl::enqueue_svm_memfill(command_queue&, svm_pointer&, pybind11::object, pybind11::object, pybind11::object)’:
  src/wrap_cl.hpp:3970:34: warning: ‘size’ may be used uninitialized [-Wmaybe-uninitialized]
   3970 |       if (have_size && user_size > size)
        |                        ~~~~~~~~~~^~~~~~
  src/wrap_cl.hpp:3960:12: note: ‘size’ was declared here
   3960 |     size_t size;
        |            ^~~~
```