### PR TITLE
Fix pooled_buffer.release()

### DIFF
--- a/src/wrap_cl.hpp
+++ b/src/wrap_cl.hpp
@@ -555,8 +555,8 @@ namespace pyopencl
     private:
       bool m_initialized;
 
-      public:
-        Py_buffer m_buf;
+    public:
+      Py_buffer m_buf;
 
     py_buffer_wrapper()
       : m_initialized(false)

--- a/src/wrap_mempool.cpp
+++ b/src/wrap_mempool.cpp
@@ -243,6 +243,13 @@ namespace pyopencl {
       {
         return m_size;
       }
+
+      // This shouldn't be necessary, but somehow nanobind gets unhappy if
+      // it's not there.
+      void free()
+      {
+        super::free();
+      }
   };
 
   // }}}

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -1543,6 +1543,17 @@ def test_zero_size_svm_allocations(ctx_factory):
     zero_sized_svm.release()
 
 
+def test_buffer_release(ctx_factory):
+    ctx = ctx_factory()
+    queue = cl.CommandQueue(ctx)
+
+    mem_pool = cl.tools.MemoryPool(cl.tools.ImmediateAllocator(queue))
+
+    b = mem_pool.allocate(1000)
+    print(type(b))
+    b.release()
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
Similar fix as `pooled_svm.release()`.

Without the extra `free()`, nanobind says:

```
TypeError: release(): incompatible function arguments. The following argument types are supported:
    1. release(self) -> None

Invoked with types: pyopencl._cl.PooledBuffer
```

See also https://github.com/illinois-ceesd/mirgecom/actions/runs/8994108270/job/24707084570