### PR TITLE
Move more configs to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,18 @@ on:
         - cron:  '17 3 * * 0'
 
 jobs:
-    flake8:
-        name: Flake8
+    ruff:
+        name: Ruff
         runs-on: ubuntu-latest
         steps:
         -   uses: actions/checkout@v4
-        -
-            uses: actions/setup-python@v5
             with:
-                # matches compat target in setup.py
-                python-version: '3.8'
+                submodules: true
+        -   uses: actions/setup-python@v5
         -   name: "Main Script"
             run: |
-                curl -L -O https://tiker.net/ci-support-v0
-                . ci-support-v0
-                install_and_run_flake8 "$(get_proj_name)" examples/*.py test/*.py
+                pip install ruff
+                ruff check
 
     pylint:
         name: Pylint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+variables:
+  GIT_SUBMODULE_STRATEGY: recursive
+
 Python 3 Intel CPU:
   script: |
     source /opt/enable-intel-cl.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,14 +168,12 @@ Python 3 POCL (+GL and special functions):
     reports:
       junit: test/pytest.xml
 
-Flake8:
+Ruff:
   script: |
-    curl -L -O https://tiker.net/ci-support-v0
-    . ci-support-v0
-    build_py_project_in_venv
-    install_and_run_flake8 "$(get_proj_name)" examples/*.py test/*.py
+    pipx install ruff
+    ruff check
   tags:
-  - python3
+  - docker-runner
   except:
   - tags
 
@@ -244,7 +242,7 @@ Downstream:
     - DOWNSTREAM_PROJECT: [loopy, boxtree, meshmode]
   tags:
   - large-node
-  - "docker-runner"
+  - docker-runner
   script: |
     curl -L -O https://tiker.net/ci-support-v0
     . ci-support-v0

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -10,4 +10,3 @@ dependencies:
 - ocl-icd
 - pocl
 - mako
-- pybind11

--- a/contrib/cldis.py
+++ b/contrib/cldis.py
@@ -36,7 +36,7 @@ import sys
 import tempfile
 
 
-def main(ctx, tmp_dir, cl_str, output=None, build_options=[]):
+def main(ctx, tmp_dir, cl_str, output=None, build_options=()):
     device = ctx.devices[0]
     platform = device.platform
     if platform.name == "NVIDIA CUDA":
@@ -86,6 +86,6 @@ if __name__ == "__main__":
         cl_file = sys.argv[1]
         with open(cl_file, "r") as f:
             cl_str = f.read()
-        output = sys.argv[2] if len(sys.argv) >=3 else None
-        build_options = sys.argv[3:] if len(sys.argv) >=4 else []
+        output = sys.argv[2] if len(sys.argv) >= 3 else None
+        build_options = sys.argv[3:] if len(sys.argv) >= 4 else []
         main(ctx, tmp_dir, cl_str, output, build_options)

--- a/contrib/fortran-to-opencl/translate.py
+++ b/contrib/fortran-to-opencl/translate.py
@@ -24,8 +24,9 @@ import re
 from sys import intern
 from warnings import warn
 
-import cgen
 import numpy as np
+
+import cgen
 import pymbolic.primitives as p
 import pytools.lex
 from pymbolic.mapper import CombineMapper
@@ -233,8 +234,12 @@ class FortranExpressionParser(ExpressionParserBase):
 
     def parse_postfix(self, pstate, min_precedence, left_exp):
         from pymbolic.parser import (
-            _PREC_CALL, _PREC_COMPARISON, _PREC_LOGICAL_AND, _PREC_LOGICAL_OR,
-            _openpar)
+            _PREC_CALL,
+            _PREC_COMPARISON,
+            _PREC_LOGICAL_AND,
+            _PREC_LOGICAL_OR,
+            _openpar,
+        )
         from pymbolic.primitives import Comparison, LogicalAnd, LogicalOr
 
         next_tag = pstate.next_tag()
@@ -941,7 +946,7 @@ class F2CLTranslator(FTreeWalkerBase):
 
             if shape is not None:
                 dim_stmt = cgen.Statement(
-                    'dimension \"fortran\" {}[{}]'.format(
+                    'dimension "fortran" {}[{}]'.format(
                         scope.translate_var_name(name),
                         ", ".join(gen_shape(s) for s in shape)
                         ))

--- a/examples/demo_meta_codepy.py
+++ b/examples/demo_meta_codepy.py
@@ -1,8 +1,18 @@
 import numpy as np
 import numpy.linalg as la
+
 from cgen import (
-    POD, Assign, Block, Const, FunctionBody, FunctionDeclaration, Initializer,
-    Module, Pointer, Value)
+    POD,
+    Assign,
+    Block,
+    Const,
+    FunctionBody,
+    FunctionDeclaration,
+    Initializer,
+    Module,
+    Pointer,
+    Value,
+)
 from cgen.opencl import CLGlobal, CLKernel, CLRequiredWorkGroupSize
 
 import pyopencl as cl

--- a/examples/svm.py
+++ b/examples/svm.py
@@ -4,8 +4,10 @@ import numpy as np
 
 import pyopencl as cl
 from pyopencl.characterize import (
-    has_coarse_grain_buffer_svm, has_fine_grain_buffer_svm,
-    has_fine_grain_system_svm)
+    has_coarse_grain_buffer_svm,
+    has_fine_grain_buffer_svm,
+    has_fine_grain_system_svm,
+)
 
 
 ctx = cl.create_some_context()

--- a/examples/transpose.py
+++ b/examples/transpose.py
@@ -204,8 +204,7 @@ def benchmark_transpose():
             a_t_buf.release()
 
     try:
-        from matplotlib.pyplot import (
-            clf, grid, legend, plot, savefig, xlabel, ylabel)
+        from matplotlib.pyplot import clf, grid, legend, plot, savefig, xlabel, ylabel
     except ModuleNotFoundError:
         pass
     else:

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -443,11 +443,11 @@ class Program:
             knl = Kernel(self, attr)
             # Nvidia does not raise errors even for invalid names,
             # but this will give an error if the kernel is invalid.
-            knl.num_args
+            knl.num_args  # noqa: B018
             knl._source = getattr(self, "_source", None)
 
             if self._build_duration_info is not None:
-                build_descr, was_cached, duration = self._build_duration_info
+                build_descr, _was_cached, duration = self._build_duration_info
                 if duration > 0.2:
                     logger.info("build program: kernel '%s' was part of a "
                             "lengthy %s (%.2f s)" % (attr, build_descr, duration))
@@ -456,9 +456,9 @@ class Program:
                 self._build_duration_info = None
 
             return knl
-        except LogicError:
+        except LogicError as err:
             raise AttributeError("'%s' was not found as a program "
-                    "info attribute or as a kernel name" % attr)
+                    "info attribute or as a kernel name" % attr) from err
 
     # {{{ build
 
@@ -780,9 +780,9 @@ def _add_functionality():
 
             try:
                 inf_attr = getattr(info_cls, name.upper())
-            except AttributeError:
+            except AttributeError as err:
                 raise AttributeError("%s has no attribute '%s'"
-                        % (type(self), name))
+                        % (type(self), name)) from err
             else:
                 return self.event.get_profiling_info(inf_attr)
 
@@ -1030,9 +1030,9 @@ def _add_functionality():
         def __getattr__(self, name):
             try:
                 inf_attr = getattr(_cl.image_info, name.upper())
-            except AttributeError:
+            except AttributeError as err:
                 raise AttributeError("%s has no attribute '%s'"
-                        % (type(self), name))
+                        % (type(self), name)) from err
             else:
                 return self.event.get_image_info(inf_attr)
 
@@ -1055,7 +1055,7 @@ def _add_functionality():
     def error_str(self):
         val = self.what
         try:
-            val.routine
+            val.routine  # noqa: B018
         except AttributeError:
             return str(val)
         else:
@@ -2097,7 +2097,7 @@ DTYPE_TO_CHANNEL_TYPE = {
     np.dtype(np.uint8): channel_type.UNSIGNED_INT8,
     }
 try:
-    np.float16
+    np.float16  # noqa: B018
 except Exception:
     pass
 else:
@@ -2272,12 +2272,12 @@ def svm_empty(ctx, flags, shape, dtype, order="C", alignment=None, queue=None):
         s = 1
         for dim in shape:
             s *= dim
-    except TypeError:
+    except TypeError as err:
         admissible_types = (int, np.integer)
 
         if not isinstance(shape, admissible_types):
             raise TypeError("shape must either be iterable or "
-                    "castable to an integer")
+                    "castable to an integer") from err
         s = shape
         shape = (shape,)
 

--- a/pyopencl/_mymako.py
+++ b/pyopencl/_mymako.py
@@ -1,6 +1,6 @@
 try:
     import mako.template  # noqa: F401
-except ImportError:
+except ImportError as err:
     raise ImportError(
             "Some of PyOpenCL's facilities require the Mako templating engine.\n"
             "You or a piece of software you have used has tried to call such a\n"
@@ -9,6 +9,6 @@ except ImportError:
             "- easy_install Mako\n"
             "- pip install Mako\n"
             "- aptitude install python-mako\n"
-            "\nor whatever else is appropriate for your system.")
+            "\nor whatever else is appropriate for your system.") from err
 
 from mako import *  # noqa: F401, F403

--- a/pyopencl/algorithm.py
+++ b/pyopencl/algorithm.py
@@ -34,6 +34,7 @@ from typing import Optional
 
 import numpy as np
 from mako.template import Template
+
 from pytools import memoize, memoize_method
 
 import pyopencl as cl
@@ -1226,8 +1227,7 @@ class ListOfListsBuilder:
                 queue, (n_objects + 1,), index_dtype, allocator=allocator)
             info_record.compressed_indices[0] = 0
 
-            compress_events[name] = compress_kernel( \
-                # pylint: disable=possibly-used-before-assignment
+            compress_events[name] = compress_kernel(  # pylint: disable=possibly-used-before-assignment
                 info_record.starts,
                 compressed_counts,
                 info_record.nonempty_indices,

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -42,9 +42,12 @@ import pyopencl.elementwise as elementwise
 from pyopencl import cltypes
 from pyopencl.characterize import has_double_support
 from pyopencl.compyte.array import (
-    ArrayFlags as _ArrayFlags, as_strided as _as_strided,
-    c_contiguous_strides as _c_contiguous_strides, equal_strides as _equal_strides,
-    f_contiguous_strides as _f_contiguous_strides)
+    ArrayFlags as _ArrayFlags,
+    as_strided as _as_strided,
+    c_contiguous_strides as _c_contiguous_strides,
+    equal_strides as _equal_strides,
+    f_contiguous_strides as _f_contiguous_strides,
+)
 
 
 SCALAR_CLASSES = (Number, np.bool_, bool)
@@ -608,11 +611,11 @@ class Array:
 
             try:
                 shape = tuple(shape)        # type: ignore[arg-type]
-            except TypeError:
+            except TypeError as err:
                 if not isinstance(shape, (int, np.integer)):
                     raise TypeError(
                         "shape must either be iterable or castable to an integer: "
-                        f"got a '{type(shape).__name__}'")
+                        f"got a '{type(shape).__name__}'") from err
 
                 shape = (shape,)
 
@@ -654,7 +657,7 @@ class Array:
             # }}}
 
             assert dtype != object, \
-                    "object arrays on the compute device are not allowed"
+                    "object arrays on the compute device are not allowed"  # noqa: E721
             assert isinstance(shape, tuple)
             assert isinstance(strides, tuple)
 
@@ -922,7 +925,7 @@ class Array:
                     "device-to-host transfers",
                     DeprecationWarning, stacklevel=2)
 
-        ary, event1 = self._get(queue=queue, ary=ary, async_=async_, **kwargs)
+        ary, _event1 = self._get(queue=queue, ary=ary, async_=async_, **kwargs)
 
         return ary
 
@@ -2370,7 +2373,7 @@ def to_device(queue, ary, allocator=None, async_=None,
 
     # }}}
 
-    if ary.dtype == object:
+    if ary.dtype == object:  # noqa: E721
         raise RuntimeError("to_device does not work on object arrays.")
 
     if array_queue is _same_as_transfer:
@@ -2874,7 +2877,7 @@ def hstack(arrays, queue=None):
 
     lead_shape = single_valued(ary.shape[:-1] for ary in arrays)
 
-    w = builtins.sum([ary.shape[-1] for ary in arrays])
+    w = builtins.sum(ary.shape[-1] for ary in arrays)
 
     if __debug__:
         if builtins.any(type(ary) != type(arrays[0])  # noqa: E721

--- a/pyopencl/bitonic_sort.py
+++ b/pyopencl/bitonic_sort.py
@@ -37,6 +37,7 @@ from functools import reduce
 from operator import mul
 
 from mako.template import Template
+
 from pytools import memoize_method
 
 import pyopencl as cl

--- a/pyopencl/cache.py
+++ b/pyopencl/cache.py
@@ -266,7 +266,7 @@ def get_cache_key(device, options_bytes, src):
 
 
 def retrieve_from_cache(cache_dir, cache_key):
-    class _InvalidInfoFile(RuntimeError):
+    class _InvalidInfoFileError(RuntimeError):
         pass
 
     from os.path import isdir, join
@@ -290,18 +290,18 @@ def retrieve_from_cache(cache_dir, cache_key):
 
                 try:
                     info_file = open(info_path, "rb")
-                except OSError:
-                    raise _InvalidInfoFile()
+                except OSError as err:
+                    raise _InvalidInfoFileError() from err
 
                 try:
                     try:
                         info = load(info_file)
-                    except EOFError:
-                        raise _InvalidInfoFile()
+                    except EOFError as err:
+                        raise _InvalidInfoFileError() from err
                 finally:
                     info_file.close()
 
-            except _InvalidInfoFile:
+            except _InvalidInfoFileError:
                 mod_cache_dir_m.reset()
                 from warnings import warn
                 warn(

--- a/pyopencl/capture_call.py
+++ b/pyopencl/capture_call.py
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 
 import numpy as np
+
 from pytools.py_codegen import Indentation, PythonCodeGenerator
 
 import pyopencl as cl
@@ -30,8 +31,8 @@ import pyopencl as cl
 def capture_kernel_call(kernel, output_file, queue, g_size, l_size, *args, **kwargs):
     try:
         source = kernel._source
-    except AttributeError:
-        raise RuntimeError("cannot capture call, kernel source not available")
+    except AttributeError as err:
+        raise RuntimeError("cannot capture call, kernel source not available") from err
 
     if source is None:
         raise RuntimeError("cannot capture call, kernel source not available")
@@ -91,9 +92,9 @@ def capture_kernel_call(kernel, output_file, queue, g_size, l_size, *args, **kwa
             else:
                 try:
                     arg_buf = memoryview(arg)
-                except Exception:
+                except Exception as err:
                     raise RuntimeError("cannot capture: "
-                            "unsupported arg nr %d (0-based)" % i)
+                            "unsupported arg nr %d (0-based)" % i) from err
 
                 arg_data.append(("arg%d_data" % i, arg_buf))
                 kernel_args.append("decompress(b64decode(arg%d_data))" % i)

--- a/pyopencl/clrandom.py
+++ b/pyopencl/clrandom.py
@@ -50,6 +50,7 @@ for some documentation if you're planning on using Random123 directly.
 # }}}
 
 import numpy as np
+
 from pytools import memoize_method
 
 import pyopencl as cl

--- a/pyopencl/elementwise.py
+++ b/pyopencl/elementwise.py
@@ -31,12 +31,19 @@ import enum
 from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
+
 from pytools import memoize_method
 
 import pyopencl as cl
 from pyopencl.tools import (
-    DtypedArgument, KernelTemplateBase, ScalarArg, VectorArg,
-    context_dependent_memoize, dtype_to_c_struct, dtype_to_ctype)
+    DtypedArgument,
+    KernelTemplateBase,
+    ScalarArg,
+    VectorArg,
+    context_dependent_memoize,
+    dtype_to_c_struct,
+    dtype_to_ctype,
+)
 
 
 # {{{ elementwise kernel code generator

--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -26,6 +26,7 @@ from typing import Any, Tuple
 from warnings import warn
 
 import numpy as np
+
 from pytools.persistent_dict import WriteOncePersistentDict
 from pytools.py_codegen import Indentation, PythonCodeGenerator
 

--- a/pyopencl/ipython_ext.py
+++ b/pyopencl/ipython_ext.py
@@ -33,7 +33,7 @@ class PyOpenCLMagics(Magics):
     def cl_kernel(self, line, cell):
         kernel = cell
 
-        opts, args = self.parse_options(line, "o:")
+        opts, _args = self.parse_options(line, "o:")
         build_options = opts.get("o", "")
 
         self._run_kernel(kernel, build_options)

--- a/pyopencl/reduction.py
+++ b/pyopencl/reduction.py
@@ -35,8 +35,12 @@ import numpy as np
 
 import pyopencl as cl
 from pyopencl.tools import (
-    DtypedArgument, KernelTemplateBase, _process_code_for_macro,
-    context_dependent_memoize, dtype_to_ctype)
+    DtypedArgument,
+    KernelTemplateBase,
+    _process_code_for_macro,
+    context_dependent_memoize,
+    dtype_to_ctype,
+)
 
 
 # {{{ kernel source
@@ -219,8 +223,11 @@ def get_reduction_kernel(
         map_expr = "pyopencl_reduction_inp[i]" if stage == 2 else "in[i]"
 
     from pyopencl.tools import (
-        VectorArg, get_arg_list_scalar_arg_dtypes, get_arg_offset_adjuster_code,
-        parse_arg_list)
+        VectorArg,
+        get_arg_list_scalar_arg_dtypes,
+        get_arg_offset_adjuster_code,
+        parse_arg_list,
+    )
 
     if arguments is None:
         raise ValueError("arguments must not be None")

--- a/pyopencl/scan.py
+++ b/pyopencl/scan.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
+
 from pytools.persistent_dict import WriteOncePersistentDict
 
 import pyopencl as cl
@@ -35,9 +36,16 @@ import pyopencl._mymako as mako
 import pyopencl.array
 from pyopencl._cluda import CLUDA_PREAMBLE
 from pyopencl.tools import (
-    DtypedArgument, KernelTemplateBase, _NumpyTypesKeyBuilder,
-    _process_code_for_macro, bitlog2, context_dependent_memoize, dtype_to_ctype,
-    get_arg_list_scalar_arg_dtypes, get_arg_offset_adjuster_code)
+    DtypedArgument,
+    KernelTemplateBase,
+    _NumpyTypesKeyBuilder,
+    _process_code_for_macro,
+    bitlog2,
+    context_dependent_memoize,
+    dtype_to_ctype,
+    get_arg_list_scalar_arg_dtypes,
+    get_arg_offset_adjuster_code,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -132,21 +132,24 @@ from sys import intern
 from typing import Any, List, Optional, Union
 
 import numpy as np
+
 from pytools import memoize, memoize_method
 from pytools.persistent_dict import KeyBuilder as KeyBuilderBase
 
 from pyopencl._cl import bitlog2, get_cl_header_version  # noqa: F401
-from pyopencl.compyte.dtypes import TypeNameNotKnown  # noqa: F401
 from pyopencl.compyte.dtypes import (  # noqa: F401
-    dtype_to_ctype, get_or_register_dtype, register_dtype)
+    TypeNameNotKnown,  # noqa: F401
+    dtype_to_ctype,
+    get_or_register_dtype,
+    register_dtype,
+)
 
 
 # Do not add a pyopencl import here: This will add an import cycle.
 
 
 def _register_types():
-    from pyopencl.compyte.dtypes import (
-        TYPE_REGISTRY, fill_registry_with_opencl_c_types)
+    from pyopencl.compyte.dtypes import TYPE_REGISTRY, fill_registry_with_opencl_c_types
 
     fill_registry_with_opencl_c_types(TYPE_REGISTRY)
 
@@ -159,8 +162,13 @@ _register_types()
 
 # {{{ imported names
 
-from pyopencl._cl import (  # noqa: F401
-    AllocatorBase, DeferredAllocator, ImmediateAllocator, MemoryPool, PooledBuffer)
+from pyopencl._cl import (
+    AllocatorBase,
+    DeferredAllocator,
+    ImmediateAllocator,
+    MemoryPool,
+    PooledBuffer,
+)
 
 
 if get_cl_header_version() >= (2, 0):
@@ -978,7 +986,7 @@ class _CDeclList:
             return
 
         for _name, field_data in sorted(dtype.fields.items()):
-            field_dtype, offset = field_data[:2]
+            field_dtype, _offset = field_data[:2]
             self.add_dtype(field_dtype)
 
         _, cdecl = match_dtype_to_c_struct(
@@ -1062,7 +1070,7 @@ def match_dtype_to_c_struct(device, name, dtype, context=None):
 
     c_fields = []
     for field_name, dtype_and_offset in fields:
-        field_dtype, offset = dtype_and_offset[:2]
+        field_dtype, _offset = dtype_and_offset[:2]
         if hasattr(field_dtype, "subdtype") and field_dtype.subdtype is not None:
             array_dtype = field_dtype.subdtype[0]
             if hasattr(array_dtype, "subdtype") and array_dtype.subdtype is not None:
@@ -1087,7 +1095,7 @@ def match_dtype_to_c_struct(device, name, dtype, context=None):
 
     cdl = _CDeclList(device)
     for _field_name, dtype_and_offset in fields:
-        field_dtype, offset = dtype_and_offset[:2]
+        field_dtype, _offset = dtype_and_offset[:2]
         cdl.add_dtype(field_dtype)
 
     pre_decls = cdl.get_declarations()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,51 @@ sdist.exclude = [
     "setup.cfg",
 ]
 
+[tool.inducer-ci-support]
+disable-editable-pip-install = true
+enable-flake8-bugbear = true
+enable-flake8-isort = true
+
+[tool.flake8]
+max-line-length = 85
+inline-quotes = "double"
+docstring-quotes = "double"
+multiline-quotes = "double"
+select = [
+    "B",    # flake8-bugbear
+    "C",    # flake8-comprehensions
+    "D",    # pydocstyle
+    "E",    # pycodestyle
+    "F",    # pyflakes
+    "I",    # flake8-isort
+    "N",    # pep8-naming
+    "Q",    # flake8-quotes
+    "W",    # pycodestyle
+]
+extend-ignore = [
+    "E123", # closing bracket does not match indentation
+    "E126", # continuation line over-indented
+    "E127", # continuation line over-indented
+    "E128", # continuation line under-indented
+    "E226", # missing whitespace around arithmetic operator
+    "E241", # multiple spaces after comma
+    "E242", # tab after comma
+    "E265", # block comment should start with #
+    "E402", # module level import not at the top of file
+    "W503", # line break before a binary operator
+]
+exclude = [
+    "examples/gl_interop_demo.py",
+    "examples/gl_particle_animation.py",
+    "pyopencl/compyte",
+]
+per-file-ignores = [
+    "examples/pi-monte-carlo.py:N,B",
+    "examples/black-hole-accretion.py:N",
+    "examples/n-body.py:N",
+    "pyopencl/__init__.py:I001,I004,I005",
+]
+
 [tool.isort]
 line_length = 85
 lines_after_imports = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,17 @@ pocl = [
     "pocl-binary-distribution>=1.2",
 ]
 test = [
+    "flake8",
+    "flake8-bugbear",
+    "flake8-comprehensions",
+    "flake8-isort",
+    "Flake8-pyproject",
+    "flake8-quotes",
+    "isort",
     "mako",
+    "mypy",
+    "pep8-naming",
+    "pylint",
     "pytest>=7",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ combine_as_imports = true
 multi_line_output = 4
 extend_skip = ["pyopencl/__init__.py", "pyopencl/compyte"]
 
+[tool.pytest.ini_options]
+markers = [
+    "bitonic: tests involving bitonic sort"
+]
+
 [tool.mypy]
 warn_unused_ignores = true
 exclude = ["pyopencl/compyte"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+build-backend = "scikit_build_core.build"
 requires = [
     "scikit-build-core >=0.9.3",
     "nanobind >=1.9.2",
@@ -7,17 +8,16 @@ requires = [
     # - Retrieved 2024-06-24, AK
     "numpy",
 ]
-build-backend = "scikit_build_core.build"
 
 [project]
 name = "pyopencl"
 version = "2024.2.7"
 description = "Python wrapper for OpenCL"
 readme = "README.rst"
-requires-python = "~=3.8"
 authors = [
     { name = "Andreas Kloeckner", email = "inform@tiker.net" },
 ]
+requires-python = "~=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -28,7 +28,7 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: C++",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Physics",
@@ -36,33 +36,53 @@ classifiers = [
 dependencies = [
     "importlib-resources; python_version<'3.9'",
     "numpy",
-    "platformdirs>=2.2.0",
+    "platformdirs>=2.2",
     "pytools>=2024.1.5",
 ]
 
 [project.optional-dependencies]
 oclgrind = [
-    "oclgrind_binary_distribution>=18.3",
+    "oclgrind-binary-distribution>=18.3",
 ]
 pocl = [
-    "pocl_binary_distribution>=1.2",
+    "pocl-binary-distribution>=1.2",
 ]
 test = [
-    "Mako",
-    "pytest>=7.0.0",
+    "mako",
+    "pytest>=7",
 ]
 
 [project.urls]
-Homepage = "https://mathema.tician.de/software/pyopencl"
 Documentation = "https://documen.tician.de/pyopencl"
+Homepage = "https://mathema.tician.de/software/pyopencl"
 Repository = "https://github.com/inducer/pyopencl"
+
+[tool.scikit-build]
+sdist.exclude = [
+    ".mypy_cache",
+    ".ci",
+    ".github",
+    ".conda-ci-build-configure.sh",
+    "doc/upload-docs.sh",
+    ".editorconfig",
+    "TODOs",
+    "run-*.sh",
+    "setup.cfg",
+]
 
 [tool.cibuildwheel]
 test-command = "pytest {project}/test"
-test-extras = ["test"]
+test-extras = [
+    "test",
+]
 
 [tool.cibuildwheel.linux]
-skip = ["pp*", "cp36-*", "cp37-*", "*_i686"]
+skip = [
+    "pp*",
+    "cp36-*",
+    "cp37-*",
+    "*_i686",
+]
 test-command = ""
 before-all = [
     "yum install -y git openssl-devel ruby",
@@ -82,7 +102,11 @@ before-all = [
 repair-wheel-command = "auditwheel repair -w {dest_dir} --lib-sdir=/.libs {wheel}"
 
 [tool.cibuildwheel.macos]
-skip = ["pp*", "cp36-*", "cp37-*"]
+skip = [
+    "pp*",
+    "cp36-*",
+    "cp37-*",
+]
 before-all = "bash {package}/scripts/build-ocl-macos.sh"
 test-command = "pytest {project}/test/test_array.py" # same limitation as conda-forge
 archs = "x86_64 arm64"
@@ -94,19 +118,11 @@ archs = "x86_64 arm64"
 MACOSX_DEPLOYMENT_TARGET = "10.14"
 
 [tool.cibuildwheel.windows]
-skip = ["*-win32", "pp*", "cp36-*", "cp37-*"]
+skip = [
+    "*-win32",
+    "pp*",
+    "cp36-*",
+    "cp37-*",
+]
 test-command = ""
 before-all = "bash {package}/scripts/build-ocl-windows.sh"
-
-[tool.scikit-build]
-sdist.exclude = [
-    ".mypy_cache",
-    ".ci",
-    ".github",
-    ".conda-ci-build-configure.sh",
-    "doc/upload-docs.sh",
-    ".editorconfig",
-    "TODOs",
-    "run-*.sh",
-    "setup.cfg",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ sdist.exclude = [
     ".editorconfig",
     "TODOs",
     "run-*.sh",
-    "setup.cfg",
 ]
 
 [tool.inducer-ci-support]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,13 @@ sdist.exclude = [
     "setup.cfg",
 ]
 
+[tool.isort]
+line_length = 85
+lines_after_imports = 2
+combine_as_imports = true
+multi_line_output = 4
+extend_skip = ["pyopencl/__init__.py", "pyopencl/compyte"]
+
 [tool.mypy]
 warn_unused_ignores = true
 exclude = ["pyopencl/compyte"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,27 @@ sdist.exclude = [
     "setup.cfg",
 ]
 
+[tool.mypy]
+warn_unused_ignores = true
+exclude = ["pyopencl/compyte"]
+
+[[tool.mypy.overrides]]
+module = [
+    "IPython.*",
+    "OpenGL.*",
+    "mako.*",
+    "matplotlib.*",
+    "pyfmmlib.*",
+    "pyopencl._cl.*",
+    "pytest.*",
+    "scipy.*",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["pyopencl.compyte.*"]
+follow_imports = "skip"
+
 [tool.cibuildwheel]
 test-command = "pytest {project}/test"
 test-extras = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,16 +48,9 @@ pocl = [
     "pocl-binary-distribution>=1.2",
 ]
 test = [
-    "flake8",
-    "flake8-bugbear",
-    "flake8-comprehensions",
-    "flake8-isort",
-    "Flake8-pyproject",
-    "flake8-quotes",
-    "isort",
+    "ruff",
     "mako",
     "mypy",
-    "pep8-naming",
     "pylint",
     "pytest>=7",
 ]
@@ -81,15 +74,10 @@ sdist.exclude = [
 
 [tool.inducer-ci-support]
 disable-editable-pip-install = true
-enable-flake8-bugbear = true
-enable-flake8-isort = true
 
-[tool.flake8]
-max-line-length = 85
-inline-quotes = "double"
-docstring-quotes = "double"
-multiline-quotes = "double"
-select = [
+[tool.ruff.lint]
+preview = true
+extend-select = [
     "B",    # flake8-bugbear
     "C",    # flake8-comprehensions
     "D",    # pydocstyle
@@ -99,37 +87,40 @@ select = [
     "N",    # pep8-naming
     "Q",    # flake8-quotes
     "W",    # pycodestyle
+    "NPY"   # numpy
 ]
 extend-ignore = [
-    "E123", # closing bracket does not match indentation
-    "E126", # continuation line over-indented
-    "E127", # continuation line over-indented
-    "E128", # continuation line under-indented
     "E226", # missing whitespace around arithmetic operator
     "E241", # multiple spaces after comma
     "E242", # tab after comma
     "E265", # block comment should start with #
     "E402", # module level import not at the top of file
-    "W503", # line break before a binary operator
+    "D",    # pydocstyle
+    "C90",  # McCabe complexity
 ]
 exclude = [
     "examples/gl_interop_demo.py",
     "examples/gl_particle_animation.py",
-    "pyopencl/compyte",
-]
-per-file-ignores = [
-    "examples/pi-monte-carlo.py:N,B",
-    "examples/black-hole-accretion.py:N",
-    "examples/n-body.py:N",
-    "pyopencl/__init__.py:I001,I004,I005",
+    "pyopencl/compyte/**/*.py",
 ]
 
-[tool.isort]
-line_length = 85
-lines_after_imports = 2
-combine_as_imports = true
-multi_line_output = 4
-extend_skip = ["pyopencl/__init__.py", "pyopencl/compyte"]
+[tool.ruff.lint.per-file-ignores]
+"examples/pi-monte-carlo.py" = ["N", "B", "F841"]
+"examples/black-hole-accretion.py" = ["N", "E501", "B"]
+"examples/n-body.py" = ["N", "E501"]
+"pyopencl/__init__.py" = ["I001"]
+"contrib/fortran-to-opencl/translate.py" = ["N802", "N815", "B"]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "double"
+docstring-quotes = "double"
+multiline-quotes = "double"
+
+[tool.ruff.lint.isort]
+known-first-party = ["pytools", "pymbolic", "cgen"]
+known-local-folder = ["pyopencl"]
+lines-after-imports = 2
+combine-as-imports = true
 
 [tool.pytest.ini_options]
 markers = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers=
-        bitonic: tests involving bitonic sort

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-# enable-flake8-bugbear
-# enable-isort
-# disable-editable-pip-install

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,36 +22,3 @@ line_length = 85
 lines_after_imports = 2
 combine_as_imports = True
 multi_line_output = 4
-
-[mypy]
-warn_unused_ignores = True
-exclude = (?x)(
-    pyopencl/compyte
-    )
-
-[mypy-IPython.*]
-ignore_missing_imports = True
-
-[mypy-OpenGL.*]
-ignore_missing_imports = True
-
-[mypy-mako.*]
-ignore_missing_imports = True
-
-[mypy-matplotlib.*]
-ignore_missing_imports = True
-
-[mypy-pyfmmlib.*]
-ignore_missing_imports = True
-
-[mypy-pyopencl._cl.*]
-ignore_missing_imports = True
-
-[mypy-pyopencl.compyte.*]
-follow_imports = skip
-
-[mypy-pytest.*]
-ignore_missing_imports = True
-
-[mypy-scipy.*]
-ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,3 @@ multiline-quotes = """
 # enable-flake8-bugbear
 # enable-isort
 # disable-editable-pip-install
-
-[isort]
-line_length = 85
-lines_after_imports = 2
-combine_as_imports = True
-multi_line_output = 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,3 @@
-[flake8]
-ignore = E126,E127,E128,E123,E226,E241,E242,E265,W503,E402
-max-line-length=85
-exclude=pyopencl/compyte/ndarray,pyopencl/compyte/array.py,gl_particle_animation.py,gl_interop_demo.py
-
-per-file-ignores=
-        examples/pi-monte-carlo.py:N,B
-        examples/black-hole-accretion.py:N
-        examples/n-body.py:N
-        pyopencl/__init__.py:I001,I004,I005
-
-inline-quotes = "
-docstring-quotes = """
-multiline-quotes = """
-
 # enable-flake8-bugbear
 # enable-isort
 # disable-editable-pip-install

--- a/test/test_algorithm.py
+++ b/test/test_algorithm.py
@@ -25,18 +25,26 @@ import sys
 import numpy as np
 import numpy.linalg as la
 import pytest
-from pytools import memoize
 from test_array import general_clrand
+
+from pytools import memoize
 
 import pyopencl as cl
 import pyopencl.array
 from pyopencl.characterize import (
-    get_pocl_version, has_double_support, has_struct_arg_count_bug)
+    get_pocl_version,
+    has_double_support,
+    has_struct_arg_count_bug,
+)
 from pyopencl.scan import (
-    ExclusiveScanKernel, GenericDebugScanKernel, GenericScanKernel,
-    InclusiveScanKernel)
-from pyopencl.tools import \
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests  # noqa: F401
+    ExclusiveScanKernel,
+    GenericDebugScanKernel,
+    GenericScanKernel,
+    InclusiveScanKernel,
+)
+from pyopencl.tools import (
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,  # noqa: F401
+)
 
 
 # {{{ elementwise
@@ -643,7 +651,7 @@ def test_copy_if(ctx_factory):
 
         crit = a_dev.dtype.type(300)
         selected = a[a > crit]
-        selected_dev, count_dev, evt = copy_if(
+        selected_dev, count_dev, _evt = copy_if(
                 a_dev, "ary[i] > myval", [("myval", crit)])
 
         assert (selected_dev.get()[:count_dev.get()] == selected).all()
@@ -670,7 +678,7 @@ def test_partition(ctx_factory):
         false_host = a[a <= crit]
 
         from pyopencl.algorithm import partition
-        true_dev, false_dev, count_true_dev, evt = partition(
+        true_dev, false_dev, count_true_dev, _evt = partition(
                 a_dev, "ary[i] > myval", [("myval", crit)])
 
         count_true_dev = count_true_dev.get()
@@ -696,7 +704,7 @@ def test_unique(ctx_factory):
         a_unique_host = np.unique(a)
 
         from pyopencl.algorithm import unique
-        a_unique_dev, count_unique_dev, evt = unique(a_dev)
+        a_unique_dev, count_unique_dev, _evt = unique(a_dev)
 
         count_unique_dev = count_unique_dev.get()
 
@@ -867,7 +875,7 @@ def test_sort(ctx_factory, scan_kernel):
 
         dev_start = time()
         print("  device")
-        (a_dev_sorted,), evt = sort(a_dev, key_bits=16)
+        (a_dev_sorted,), _evt = sort(a_dev, key_bits=16)
         queue.finish()
         dev_end = time()
         print("  numpy")
@@ -907,7 +915,7 @@ def test_list_builder(ctx_factory):
             }
             """, arg_decls=[])
 
-    result, evt = builder(queue, 2000)
+    result, _evt = builder(queue, 2000)
 
     inf = result["mylist"]
     assert inf.count == 3000
@@ -932,7 +940,7 @@ def test_list_builder_with_memoryobject(ctx_factory):
 
     n = 10000
     input_list = cl.array.zeros(queue, (n,), float)
-    result, evt = builder(queue, n, input_list.data)
+    result, _evt = builder(queue, n, input_list.data)
 
     inf = result["mylist"]
     assert inf.count == n
@@ -960,7 +968,7 @@ def test_list_builder_with_offset(ctx_factory):
     input_list = cl.array.zeros(queue, (n + 10,), float)
     input_list[10:] = 1
 
-    result, evt = builder(queue, n, input_list[10:])
+    result, _evt = builder(queue, n, input_list[10:])
 
     inf = result["mylist"]
     assert inf.count == n
@@ -996,7 +1004,7 @@ def test_list_builder_with_empty_elim(ctx_factory):
         arg_decls=[],
         eliminate_empty_output_lists=["mylist1", "mylist2"])
 
-    result, evt = builder(queue, 1000)
+    result, _evt = builder(queue, 1000)
 
     mylist1 = result["mylist1"]
     assert mylist1.count == 19900
@@ -1029,7 +1037,7 @@ def test_key_value_sorter(ctx_factory):
 
     from pyopencl.algorithm import KeyValueSorter
     kvs = KeyValueSorter(context)
-    starts, lists, evt = kvs(queue, keys, values, nkeys, starts_dtype=np.int32)
+    starts, lists, _evt = kvs(queue, keys, values, nkeys, starts_dtype=np.int32)
 
     starts = starts.get()
     lists = lists.get()
@@ -1088,7 +1096,7 @@ def test_bitonic_sort(ctx_factory, size, dtype):
             and cl.get_cl_header_version() < (1, 2)):
         sgs.finish()
     sorter = BitonicSort(ctx)
-    sgs, evt = sorter(sgs, axis=1)
+    sgs, _evt = sorter(sgs, axis=1)
     assert np.array_equal(np.sort(s.get(), axis=1), sgs.get())
 
 
@@ -1157,7 +1165,7 @@ def test_bitonic_argsort(ctx_factory, size, dtype):
             and cl.get_cl_header_version() < (1, 2)):
         ms.finish()
         index.finish()
-    ms, evt = sorterm(ms, idx=index, axis=0)
+    ms, _evt = sorterm(ms, idx=index, axis=0)
 
     assert np.array_equal(np.sort(m.get()), ms.get())
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -37,8 +37,9 @@ import pyopencl.cltypes as cltypes
 import pyopencl.tools as cl_tools
 from pyopencl.characterize import has_double_support, has_struct_arg_count_bug
 from pyopencl.clrandom import PhiloxGenerator, ThreefryGenerator
-from pyopencl.tools import \
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests  # noqa: F401
+from pyopencl.tools import (
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,  # noqa: F401
+)
 
 
 _PYPY = cl._PYPY
@@ -302,7 +303,7 @@ def test_custom_type_zeros(ctx_factory):
     from pyopencl.tools import get_or_register_dtype, match_dtype_to_c_struct
 
     name = "mmc_type"
-    dtype, c_decl = match_dtype_to_c_struct(queue.device, name, dtype)
+    dtype, _c_decl = match_dtype_to_c_struct(queue.device, name, dtype)
     dtype = get_or_register_dtype(name, dtype)
 
     n = 1000
@@ -334,7 +335,7 @@ def test_custom_type_fill(ctx_factory):
     from pyopencl.tools import get_or_register_dtype, match_dtype_to_c_struct
 
     name = "mmc_type"
-    dtype, c_decl = match_dtype_to_c_struct(queue.device, name, dtype)
+    dtype, _c_decl = match_dtype_to_c_struct(queue.device, name, dtype)
     dtype = get_or_register_dtype(name, dtype)
 
     n = 1000
@@ -362,7 +363,7 @@ def test_custom_type_take_put(ctx_factory):
     from pyopencl.tools import get_or_register_dtype, match_dtype_to_c_struct
 
     name = "tp_type"
-    dtype, c_decl = match_dtype_to_c_struct(queue.device, name, dtype)
+    dtype, _c_decl = match_dtype_to_c_struct(queue.device, name, dtype)
     dtype = get_or_register_dtype(name, dtype)
 
     n = 100

--- a/test/test_arrays_in_structs.py
+++ b/test/test_arrays_in_structs.py
@@ -26,8 +26,9 @@ import pyopencl as cl
 import pyopencl.cltypes as cltypes
 import pyopencl.tools as cl_tools
 from pyopencl import mem_flags
-from pyopencl.tools import \
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests  # noqa: F401
+from pyopencl.tools import (
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,  # noqa: F401
+)
 
 
 def test_struct_with_array_fields(ctx_factory):

--- a/test/test_clmath.py
+++ b/test/test_clmath.py
@@ -29,8 +29,9 @@ import pyopencl as cl
 import pyopencl.array as cl_array
 import pyopencl.clmath as clmath
 from pyopencl.characterize import has_double_support, has_struct_arg_count_bug
-from pyopencl.tools import \
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests  # noqa: F401
+from pyopencl.tools import (
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,  # noqa: F401
+)
 
 
 try:

--- a/test/test_clrandom.py
+++ b/test/test_clrandom.py
@@ -27,8 +27,9 @@ import pyopencl as cl
 import pyopencl.clrandom as clrandom
 import pyopencl.cltypes as cltypes
 from pyopencl.characterize import has_double_support
-from pyopencl.tools import \
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests  # noqa: F401
+from pyopencl.tools import (
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,  # noqa: F401
+)
 
 
 try:

--- a/test/test_enqueue_copy.py
+++ b/test/test_enqueue_copy.py
@@ -27,8 +27,9 @@ import pytest
 
 import pyopencl as cl
 from pyopencl.characterize import get_pocl_version
-from pyopencl.tools import \
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests  # noqa: F401
+from pyopencl.tools import (
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,  # noqa: F401
+)
 
 
 def generate_slice(start, shape):

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -29,9 +29,11 @@ import pyopencl.array as cl_array
 import pyopencl.clrandom
 import pyopencl.cltypes as cltypes
 from pyopencl.characterize import get_pocl_version
-from pyopencl.tools import \
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests  # noqa: F401
-from pyopencl.tools import DeferredAllocator, ImmediateAllocator
+from pyopencl.tools import (
+    DeferredAllocator,
+    ImmediateAllocator,
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,  # noqa: F401
+)
 
 
 def _xfail_if_pocl(plat, up_to_version, msg="unsupported by PoCL"):
@@ -55,8 +57,8 @@ def test_get_info(ctx_factory):
     platform = device.platform
 
     with pytest.deprecated_call():
-        device.persistent_unique_id
-    device.hashable_model_and_version_identifier
+        device.persistent_unique_id  # noqa: B018
+    device.hashable_model_and_version_identifier  # noqa: B018
 
     failure_count = [0]
 
@@ -225,8 +227,8 @@ def test_get_info(ctx_factory):
         img = cl.Image(ctx, cl.mem_flags.READ_ONLY, img_format, (128, 256))
         assert img.shape == (128, 256)
 
-        img.depth
-        img.image.depth
+        img.depth  # noqa: B018
+        img.image.depth  # noqa: B018
         do_test(img, cl.image_info,
                 lambda info: img.get_image_info(info))
 
@@ -297,7 +299,7 @@ def test_invalid_kernel_names_cause_failures(ctx_factory):
         """).build()
 
     try:
-        prg.sam
+        prg.sam  # noqa: B018
         raise RuntimeError("invalid kernel name did not cause error")
     except AttributeError:
         pass
@@ -1289,7 +1291,7 @@ def test_map_dtype(ctx_factory, dtype):
     b = pyopencl.Buffer(ctx,
                         pyopencl.mem_flags.READ_ONLY,
                         dt.itemsize)
-    array, ev = pyopencl.enqueue_map_buffer(queue, b, pyopencl.map_flags.WRITE, 0,
+    array, _ev = pyopencl.enqueue_map_buffer(queue, b, pyopencl.map_flags.WRITE, 0,
                                             (1,), dt)
     with array.base:
         print(array.dtype)


### PR DESCRIPTION
It's the future! :tada: 

This mostly removes `pytest.ini` and moves most of the things from `setup.cfg` here. 

Flake8 doesn't support `pyproject`, so it's not moved, but there is a project that hacks support in there if we want:
https://github.com/john-hen/Flake8-pyproject