### PR TITLE
Add and fix some more ruff rules

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.17.0
+        run: python -m pip install cibuildwheel==2.19.2
 
       - name: Build wheels
         shell: bash

--- a/contrib/cldis.py
+++ b/contrib/cldis.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         import pyopencl as cl
         ctx = cl.create_some_context()
         cl_file = sys.argv[1]
-        with open(cl_file, "r") as f:
+        with open(cl_file) as f:
             cl_str = f.read()
         output = sys.argv[2] if len(sys.argv) >= 3 else None
         build_options = sys.argv[3:] if len(sys.argv) >= 4 else []

--- a/contrib/fortran-to-opencl/setup.cfg
+++ b/contrib/fortran-to-opencl/setup.cfg
@@ -1,8 +1,0 @@
-[flake8]
-ignore = E126,E127,E128,E123,E226,E241,E242,E265,N802,W503,N815
-max-line-length=85
-
-inline-quotes = "
-docstring-quotes = """
-multiline-quotes = """
-

--- a/examples/black-hole-accretion.py
+++ b/examples/black-hole-accretion.py
@@ -2025,7 +2025,7 @@ if __name__ == "__main__":
     # Tracksave of trajectories
     TrackSave = False
 
-    HowToUse = "%s -h [Help] -b [BlackBodyEmission] -j [TrackSave] -n [NoImage] -p <Einstein/Newton> -s <SizeInPixels> -m <Mass> -i <DiscInternalRadius> -x <DiscExternalRadius> -a <AngleAboveDisc> -d <DeviceId> -c <Greyscale/Red2Yellow> -g <CUDA/OpenCL> -o <EachPixel/TrajectoCircle/TrajectoPixel/EachCircle/Original> -t <ThreadsInCuda> -v <FP32/FP64> -k <TrackPoints>"  # noqa: E501
+    HowToUse = "%s -h [Help] -b [BlackBodyEmission] -j [TrackSave] -n [NoImage] -p <Einstein/Newton> -s <SizeInPixels> -m <Mass> -i <DiscInternalRadius> -x <DiscExternalRadius> -a <AngleAboveDisc> -d <DeviceId> -c <Greyscale/Red2Yellow> -g <CUDA/OpenCL> -o <EachPixel/TrajectoCircle/TrajectoPixel/EachCircle/Original> -t <ThreadsInCuda> -v <FP32/FP64> -k <TrackPoints>"
 
     try:
         opts, args = getopt.getopt(

--- a/examples/n-body.py
+++ b/examples/n-body.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
+
 """
 NBody Demonstrator implemented in OpenCL, rendering OpenGL
 

--- a/examples/n-body.py
+++ b/examples/n-body.py
@@ -676,7 +676,7 @@ if __name__ == "__main__":
     # Type of Interaction
     InterType = "Force"
 
-    HowToUse = "%s -h [Help] -r [InitialRandom] -g [OpenGL] -e [VirielStress] -o [Verbose] -p [Potential] -x <None|NegExp|CorRad> -d <DeviceId> -n <NumberOfParticules> -i <Iterations> -z <SizeOfBoxOrBall> -v <Velocity> -s <Step> -b <Ball|Box> -m <ImplicitEuler|RungeKutta|ExplicitEuler|Heun> -t <FP32|FP64>"  # noqa: E501
+    HowToUse = "%s -h [Help] -r [InitialRandom] -g [OpenGL] -e [VirielStress] -o [Verbose] -p [Potential] -x <None|NegExp|CorRad> -d <DeviceId> -n <NumberOfParticules> -i <Iterations> -z <SizeOfBoxOrBall> -v <Velocity> -s <Step> -b <Ball|Box> -m <ImplicitEuler|RungeKutta|ExplicitEuler|Heun> -t <FP32|FP64>"
 
     try:
         opts, args = getopt.getopt(
@@ -833,8 +833,8 @@ if __name__ == "__main__":
 
     # Build all routines used for the computing
 
-    # BuildOptions="-cl-mad-enable -cl-kernel-arg-info -cl-fast-relaxed-math -cl-std=CL1.2 -DTRNG=%i -DTYPE=%i" % (Marsaglia[RNG],Computing[ValueType])  # noqa: E501
-    BuildOptions = "-cl-mad-enable -cl-fast-relaxed-math -DTRNG=%i -DTYPE=%i -DINTERACTION=%i -DARTEVASION=%i" % (  # noqa: E501
+    # BuildOptions="-cl-mad-enable -cl-kernel-arg-info -cl-fast-relaxed-math -cl-std=CL1.2 -DTRNG=%i -DTYPE=%i" % (Marsaglia[RNG],Computing[ValueType])
+    BuildOptions = "-cl-mad-enable -cl-fast-relaxed-math -DTRNG=%i -DTYPE=%i -DINTERACTION=%i -DARTEVASION=%i" % (
         Marsaglia[RNG],
         Computing[ValueType],
         Interaction[InterType],
@@ -864,7 +864,7 @@ if __name__ == "__main__":
     # Write/HostPointer approach for buffering
     # clDataX = cl.Buffer(ctx, mf.WRITE_ONLY|mf.COPY_HOST_PTR,hostbuf=MyDataX)
     # clDataV = cl.Buffer(ctx, mf.WRITE_ONLY|mf.COPY_HOST_PTR,hostbuf=MyDataV)
-    # clPotential = cl.Buffer(ctx, mf.WRITE_ONLY|mf.COPY_HOST_PTR,hostbuf=MyPotential)  # noqa: E501
+    # clPotential = cl.Buffer(ctx, mf.WRITE_ONLY|mf.COPY_HOST_PTR,hostbuf=MyPotential)
     # clKinetic = cl.Buffer(ctx, mf.WRITE_ONLY|mf.COPY_HOST_PTR,hostbuf=MyKinetic)
     # clCoM = cl.Buffer(ctx, mf.WRITE_ONLY|mf.COPY_HOST_PTR,hostbuf=MyCoM)
 
@@ -1011,7 +1011,7 @@ if __name__ == "__main__":
     )
 
     print(
-        "Duration stats on device %s with %s iterations :\n\tMean:\t%s\n\tMedian:\t%s\n\tStddev:\t%s\n\tMin:\t%s\n\tMax:\t%s\n\n\tVariability:\t%s\n"  # noqa: E501
+        "Duration stats on device %s with %s iterations :\n\tMean:\t%s\n\tMedian:\t%s\n\tStddev:\t%s\n\tMin:\t%s\n\tMax:\t%s\n\n\tVariability:\t%s\n"
         % (
             Device,
             Iterations,
@@ -1029,7 +1029,7 @@ if __name__ == "__main__":
     FPS /= Durations
 
     print(
-        "FPS stats on device %s with %s iterations :\n\tMean:\t%s\n\tMedian:\t%s\n\tStddev:\t%s\n\tMin:\t%s\n\tMax:\t%s\n"  # noqa: E501
+        "FPS stats on device %s with %s iterations :\n\tMean:\t%s\n\tMedian:\t%s\n\tStddev:\t%s\n\tMin:\t%s\n\tMax:\t%s\n"
         % (
             Device,
             Iterations,
@@ -1047,7 +1047,7 @@ if __name__ == "__main__":
     Squertz /= Durations
 
     print(
-        "Squertz in log10 & complete stats on device %s with %s iterations :\n\tMean:\t%s\t%s\n\tMedian:\t%s\t%s\n\tStddev:\t%s\t%s\n\tMin:\t%s\t%s\n\tMax:\t%s\t%s\n"  # noqa: E501
+        "Squertz in log10 & complete stats on device %s with %s iterations :\n\tMean:\t%s\t%s\n\tMedian:\t%s\t%s\n\tStddev:\t%s\t%s\n\tMin:\t%s\t%s\n\tMax:\t%s\t%s\n"
         % (
             Device,
             Iterations,

--- a/examples/pi-monte-carlo.py
+++ b/examples/pi-monte-carlo.py
@@ -492,8 +492,8 @@ def MetropolisCuda(InputCU):
     except Exception:
         print("Compilation seems to break")
 
-    MetropolisBlocksCU = mod.get_function("MainLoopBlocks")  # noqa: F841
-    MetropolisThreadsCU = mod.get_function("MainLoopThreads")  # noqa: F841
+    MetropolisBlocksCU = mod.get_function("MainLoopBlocks")
+    MetropolisThreadsCU = mod.get_function("MainLoopThreads")
     MetropolisHybridCU = mod.get_function("MainLoopHybrid")
 
     MyDuration = numpy.zeros(steps)
@@ -1163,4 +1163,5 @@ if __name__ == "__main__":
         )
 
     if Fit:
-        FitAndPrint(ExploredJobs, median, Curves)  # noqa: F821, E501 # FIXME: undefined var 'median'
+        # FIXME: undefined var 'median'
+        FitAndPrint(ExploredJobs, median, Curves)  # noqa: F821

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from warnings import warn
 
 # must import, otherwise dtype registry will not be fully populated
-import pyopencl.cltypes  # noqa: F401
+import pyopencl.cltypes
 from pyopencl.version import VERSION, VERSION_STATUS, VERSION_TEXT  # noqa: F401
 
 
@@ -54,7 +54,7 @@ except ImportError:
             stacklevel=2)
     raise
 
-import numpy as np  # noqa: I003
+import numpy as np
 
 import sys
 
@@ -187,14 +187,14 @@ if not _PYPY:
 if get_cl_header_version() >= (1, 1):
     from pyopencl._cl import UserEvent  # noqa: F401
 if get_cl_header_version() >= (1, 2):
-    from pyopencl._cl import ImageDescriptor  # noqa: F401
+    from pyopencl._cl import ImageDescriptor
     from pyopencl._cl import (  # noqa: F401
         _enqueue_barrier_with_wait_list, _enqueue_fill_buffer,
         _enqueue_marker_with_wait_list, enqueue_fill_image,
         enqueue_migrate_mem_objects, unload_platform_compiler)
 
 if get_cl_header_version() >= (2, 0):
-    from pyopencl._cl import SVM, SVMAllocation, SVMPointer  # noqa: F401
+    from pyopencl._cl import SVM, SVMAllocation, SVMPointer
 
 if _cl.have_gl():
     from pyopencl._cl import (  # noqa: F401
@@ -2400,7 +2400,7 @@ _KERNEL_ARG_CLASSES: Tuple[type, ...] = (
         LocalMemory,
         )
 if get_cl_header_version() >= (2, 0):
-    _KERNEL_ARG_CLASSES = _KERNEL_ARG_CLASSES + (SVM,)
+    _KERNEL_ARG_CLASSES = (*_KERNEL_ARG_CLASSES, SVM)
 
 
 # vim: foldmethod=marker

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -449,8 +449,9 @@ class Program:
             if self._build_duration_info is not None:
                 build_descr, _was_cached, duration = self._build_duration_info
                 if duration > 0.2:
-                    logger.info("build program: kernel '%s' was part of a "
-                            "lengthy %s (%.2f s)" % (attr, build_descr, duration))
+                    logger.info(
+                        "build program: kernel '%s' was part of a "
+                        "lengthy %s (%.2f s)", attr, build_descr, duration)
 
                 # don't whine about build times more than once.
                 self._build_duration_info = None

--- a/pyopencl/_mymako.py
+++ b/pyopencl/_mymako.py
@@ -11,4 +11,4 @@ except ImportError as err:
             "- aptitude install python-mako\n"
             "\nor whatever else is appropriate for your system.") from err
 
-from mako import *  # noqa: F401, F403
+from mako import *  # noqa: F403

--- a/pyopencl/algorithm.py
+++ b/pyopencl/algorithm.py
@@ -977,8 +977,10 @@ class ListOfListsBuilder:
         knl = getattr(prg, kernel_name)
 
         from pyopencl.tools import get_arg_list_scalar_arg_dtypes
-        knl.set_scalar_arg_dtypes(get_arg_list_scalar_arg_dtypes(
-            kernel_list_args+self.arg_decls) + [index_dtype])
+        knl.set_scalar_arg_dtypes([
+            *get_arg_list_scalar_arg_dtypes([*kernel_list_args, *self.arg_decls]),
+            index_dtype
+            ])
 
         return knl
 
@@ -1050,8 +1052,9 @@ class ListOfListsBuilder:
         knl = getattr(prg, kernel_name)
 
         from pyopencl.tools import get_arg_list_scalar_arg_dtypes
-        knl.set_scalar_arg_dtypes(get_arg_list_scalar_arg_dtypes(
-            kernel_list_args+self.arg_decls) + [index_dtype])
+        knl.set_scalar_arg_dtypes([
+            *get_arg_list_scalar_arg_dtypes(kernel_list_args + self.arg_decls),
+            index_dtype])
 
         return knl
 
@@ -1233,7 +1236,7 @@ class ListOfListsBuilder:
                 info_record.nonempty_indices,
                 info_record.compressed_indices,
                 info_record.num_nonempty_lists,
-                wait_for=[count_event] + info_record.compressed_indices.events)
+                wait_for=[count_event, *info_record.compressed_indices.events])
 
             info_record.starts = compressed_counts
 

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -3159,8 +3159,8 @@ def _logical_op(x1, x2, out, operator, queue=None):
         else:
             out[:] = np.logical_or(x1, x2)
     elif np.isscalar(x1) or np.isscalar(x2):
-        scalar_arg, = [x for x in (x1, x2) if np.isscalar(x)]
-        ary_arg, = [x for x in (x1, x2) if not np.isscalar(x)]
+        scalar_arg, = (x for x in (x1, x2) if np.isscalar(x))
+        ary_arg, = (x for x in (x1, x2) if not np.isscalar(x))
         queue = queue or ary_arg.queue
         allocator = ary_arg.allocator
 

--- a/pyopencl/bitonic_sort.py
+++ b/pyopencl/bitonic_sort.py
@@ -35,6 +35,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from functools import reduce
 from operator import mul
+from typing import ClassVar, Dict
 
 from mako.template import Template
 
@@ -63,7 +64,7 @@ class BitonicSort:
     .. automethod:: __call__
     """
 
-    kernels_srcs = {
+    kernels_srcs: ClassVar[Dict[str, str]] = {
             "B2": _tmpl.ParallelBitonic_B2,
             "B4": _tmpl.ParallelBitonic_B4,
             "B8": _tmpl.ParallelBitonic_B8,

--- a/pyopencl/bitonic_sort_templates.py
+++ b/pyopencl/bitonic_sort_templates.py
@@ -488,7 +488,7 @@ __kernel void run(__global const data_t * in,__global data_t * out,__local data_
   // Write output
   out[i] = aux[i];
 }
-"""         # noqa: E501
+"""
 
 # }}}
 

--- a/pyopencl/cache.py
+++ b/pyopencl/cache.py
@@ -42,12 +42,14 @@ import hashlib
 new_hash = hashlib.md5
 
 
-def _erase_dir(dir):
+def _erase_dir(directory):
     from os import listdir, rmdir, unlink
     from os.path import join
-    for name in listdir(dir):
-        unlink(join(dir, name))
-    rmdir(dir)
+
+    for name in listdir(directory):
+        unlink(join(directory, name))
+
+    rmdir(directory)
 
 
 def update_checksum(checksum, obj):
@@ -213,7 +215,7 @@ def get_dependencies(src, include_path):
 
     _inner(src)
 
-    result = [(name,) + vals for name, vals in result.items()]
+    result = [(name, *vals) for name, vals in result.items()]
     result.sort()
 
     return result
@@ -505,7 +507,7 @@ def create_built_program_from_source_cached(ctx, src, options_bytes, devices=Non
     except Exception as e:
         from pyopencl import Error
         build_program_failure = (isinstance(e, Error)
-                and e.code == _cl.status_code.BUILD_PROGRAM_FAILURE)  # noqa pylint:disable=no-member
+                and e.code == _cl.status_code.BUILD_PROGRAM_FAILURE)  # pylint:disable=no-member
 
         # Mac error on intel CPU driver: can't build from cached version.
         # If we get a build_program_failure from the cached version then

--- a/pyopencl/cache.py
+++ b/pyopencl/cache.py
@@ -462,13 +462,11 @@ def _create_built_program_from_source_cached(ctx, src, options_bytes,
                     binary_path = mod_cache_dir_m.sub("binary")
                     source_path = mod_cache_dir_m.sub("source.cl")
 
-                    outf = open(source_path, "wt")
-                    outf.write(src)
-                    outf.close()
+                    with open(source_path, "w") as outf:
+                        outf.write(src)
 
-                    outf = open(binary_path, "wb")
-                    outf.write(binary)
-                    outf.close()
+                    with open(binary_path, "wb") as outf:
+                        outf.write(binary)
 
                     from pickle import dump
                     info_file = open(info_path, "wb")

--- a/pyopencl/cache.py
+++ b/pyopencl/cache.py
@@ -375,13 +375,13 @@ def _create_built_program_from_source_cached(ctx, src, options_bytes,
         cache_result = retrieve_from_cache(cache_dir, cache_key)
 
         if cache_result is None:
-            logger.debug("build program: binary cache miss (key: %s)" % cache_key)
+            logger.debug("build program: binary cache miss (key: %s)", cache_key)
 
             to_be_built_indices.append(i)
             binaries.append(None)
             logs.append(None)
         else:
-            logger.debug("build program: binary cache hit (key: %s)" % cache_key)
+            logger.debug("build program: binary cache hit (key: %s)", cache_key)
 
             binary, log = cache_result
             binaries.append(binary)
@@ -410,8 +410,9 @@ def _create_built_program_from_source_cached(ctx, src, options_bytes,
         src = src + "\n\n__constant int pyopencl_defeat_cache_%s = 0;" % (
                 uuid4().hex)
 
-        logger.debug("build program: start building program from source on %s"
-                % ", ".join(str(devices[i]) for i in to_be_built_indices))
+        logger.debug(
+                "build program: start building program from source on %s",
+                ", ".join(str(devices[i]) for i in to_be_built_indices))
 
         prg = _cl._Program(ctx, src)
         prg.build(options_bytes, [devices[i] for i in to_be_built_indices])

--- a/pyopencl/invoker.py
+++ b/pyopencl/invoker.py
@@ -262,13 +262,13 @@ def _generate_enqueue_and_set_args_module(function_name,
     enqueue_name = "enqueue_knl_%s" % function_name
     gen("def %s(%s):"
             % (enqueue_name,
-                ", ".join(
-                    ["self", "queue", "global_size", "local_size"]
-                    + arg_names
-                    + ["global_offset=None",
-                        "g_times_l=False",
-                        "allow_empty_ndrange=False",
-                        "wait_for=None"])))
+                ", ".join([
+                    "self", "queue", "global_size", "local_size",
+                    *arg_names,
+                    "global_offset=None",
+                    "g_times_l=False",
+                    "allow_empty_ndrange=False",
+                    "wait_for=None"])))
 
     with Indentation(gen):
         subgen, wait_for_parts = gen_arg_setting(in_enqueue=True)
@@ -296,7 +296,7 @@ def _generate_enqueue_and_set_args_module(function_name,
 
     gen("")
     gen("def set_args(%s):"
-            % (", ".join(["self"] + arg_names)))
+            % (", ".join(["self", *arg_names])))
 
     with Indentation(gen):
         gen.extend(gen_arg_setting(in_enqueue=False))

--- a/pyopencl/reduction.py
+++ b/pyopencl/reduction.py
@@ -236,9 +236,9 @@ def get_reduction_kernel(
     arg_prep = get_arg_offset_adjuster_code(arguments)
 
     if stage == 2 and arguments is not None:
-        arguments = (
-                [VectorArg(dtype_out, "pyopencl_reduction_inp")]
-                + arguments)
+        arguments = [
+                VectorArg(dtype_out, "pyopencl_reduction_inp"),
+                *arguments]
 
     source, group_size = _get_reduction_source(
             ctx, dtype_to_ctype(dtype_out), dtype_out.itemsize,
@@ -519,8 +519,7 @@ class ReductionKernel:
                     use_queue,
                     (group_count*stage_inf.group_size,),
                     (stage_inf.group_size,),
-                    *([result.base_data, result.offset]
-                        + invocation_args + size_args),
+                    *([result.base_data, result.offset, *invocation_args, *size_args]),
                     wait_for=wait_for)
             wait_for = [last_evt]
 
@@ -533,7 +532,7 @@ class ReductionKernel:
                     return result
             else:
                 stage_inf = self.stage_2_inf
-                args = (result,) + stage1_args
+                args = (result, *stage1_args)
 
                 range_ = slice_ = None
 

--- a/pyopencl/scan.py
+++ b/pyopencl/scan.py
@@ -1186,7 +1186,7 @@ class GenericScanKernel(GenericScanKernelBase):
                 result = generic_scan_kernel_cache[cache_key]
                 from_cache = True
                 logger.debug(
-                    "cache hit for generated scan kernel '%s'" % self.name_prefix)
+                    "cache hit for generated scan kernel '%s'", self.name_prefix)
                 (
                     self.first_level_scan_gen_info,
                     self.second_level_scan_gen_info,
@@ -1196,7 +1196,7 @@ class GenericScanKernel(GenericScanKernelBase):
 
         if not from_cache:
             logger.debug(
-                    "cache miss for generated scan kernel '%s'" % self.name_prefix)
+                    "cache miss for generated scan kernel '%s'", self.name_prefix)
             self._finish_setup_impl()
 
             result = (self.first_level_scan_gen_info,

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -138,7 +138,7 @@ from pytools.persistent_dict import KeyBuilder as KeyBuilderBase
 
 from pyopencl._cl import bitlog2, get_cl_header_version  # noqa: F401
 from pyopencl.compyte.dtypes import (  # noqa: F401
-    TypeNameNotKnown,  # noqa: F401
+    TypeNameNotKnown,
     dtype_to_ctype,
     get_or_register_dtype,
     register_dtype,
@@ -172,7 +172,7 @@ from pyopencl._cl import (
 
 
 if get_cl_header_version() >= (2, 0):
-    from pyopencl._cl import PooledSVM, SVMAllocator, SVMPool  # noqa: F401
+    from pyopencl._cl import PooledSVM, SVMAllocator, SVMPool
 
 # }}}
 
@@ -661,7 +661,8 @@ def get_pyopencl_fixture_arg_names(metafunc, extra_arg_names=None):
     supported_arg_names = [
             "platform", "device",
             "ctx_factory", "ctx_getter",
-            ] + extra_arg_names
+            *extra_arg_names
+            ]
 
     arg_names = []
     for arg in supported_arg_names:
@@ -1129,7 +1130,8 @@ def match_dtype_to_c_struct(device, name, dtype, context=None):
     prg = cl.Program(context, src)
     knl = prg.build(devices=[device]).get_size_and_offsets
 
-    import pyopencl.array  # noqa: F401
+    import pyopencl.array
+
     result_buf = cl.array.empty(queue, 1+len(fields), np.uint32)
     knl(queue, (1,), (1,), result_buf.data)
     queue.finish()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,7 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} --lib-sdir=/.libs {wheel
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = [
-    "apk add ruby git openssl-dev",
+    "apk add ruby git openssl-dev libtool",
     "bash {package}/scripts/build-ocl.sh",
 ]
 repair-wheel-command = "auditwheel repair -w {dest_dir} --lib-sdir=/.libs {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ extend-select = [
     "NPY",  # numpy
     "Q",    # flake8-quotes
     "RUF",  # ruff
+    "UP",   # pyupgrade
     "W",    # pycodestyle
 ]
 extend-ignore = [
@@ -99,6 +100,8 @@ extend-ignore = [
     "E402", # module level import not at the top of file
     "D",    # pydocstyle
     "C90",  # McCabe complexity
+    "UP031", # use f-strings instead of %
+    "UP032", # use f-strings instead of .format
 ]
 exclude = [
     "examples/gl_interop_demo.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,15 +79,17 @@ disable-editable-pip-install = true
 preview = true
 extend-select = [
     "B",    # flake8-bugbear
-    "C",    # flake8-comprehensions
+    "C4",   # flake8-comprehensions
     "D",    # pydocstyle
     "E",    # pycodestyle
     "F",    # pyflakes
+    "G",    # flake8-logging-format
     "I",    # flake8-isort
     "N",    # pep8-naming
+    "NPY",  # numpy
     "Q",    # flake8-quotes
+    "RUF",  # ruff
     "W",    # pycodestyle
-    "NPY"   # numpy
 ]
 extend-ignore = [
     "E226", # missing whitespace around arithmetic operator

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -2336,7 +2336,7 @@ def test_logical_not(ctx_factory):
         cl_array.logical_not(cl_array.zeros(cq, 10, np.float64)).get(),
         np.logical_not(np.zeros(10)))
     np.testing.assert_array_equal(
-        cl_array.logical_not((cl_array.zeros(cq, 10, np.float64) + 1)).get(),
+        cl_array.logical_not(cl_array.zeros(cq, 10, np.float64) + 1).get(),
         np.logical_not(np.ones(10)))
 
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -606,7 +606,7 @@ def test_divide_scalar(ctx_factory):
                   np.float32, np.complex64)
     from pyopencl.characterize import has_double_support
     if has_double_support(queue.device):
-        dtypes = dtypes + (np.float64, np.complex128)
+        dtypes = (*dtypes, np.float64, np.complex128)
 
     from itertools import product
 
@@ -639,7 +639,7 @@ def test_divide_array(ctx_factory):
     dtypes = (np.float32, np.complex64)
     from pyopencl.characterize import has_double_support
     if has_double_support(queue.device):
-        dtypes = dtypes + (np.float64, np.complex128)
+        dtypes = (*dtypes, np.float64, np.complex128)
 
     from itertools import product
 
@@ -679,7 +679,7 @@ def test_divide_inplace_scalar(ctx_factory):
                   np.float32, np.complex64)
     from pyopencl.characterize import has_double_support
     if has_double_support(queue.device):
-        dtypes = dtypes + (np.float64, np.complex128)
+        dtypes = (*dtypes, np.float64, np.complex128)
 
     from itertools import product
 
@@ -715,7 +715,7 @@ def test_divide_inplace_array(ctx_factory):
                   np.float32, np.complex64)
     from pyopencl.characterize import has_double_support
     if has_double_support(queue.device):
-        dtypes = dtypes + (np.float64, np.complex128)
+        dtypes = (*dtypes, np.float64, np.complex128)
 
     from itertools import product
 

--- a/test/test_clmath.py
+++ b/test/test_clmath.py
@@ -167,7 +167,7 @@ def test_fmod(ctx_factory):
         b = clmath.fmod(a, a2)
 
         # https://salsa.debian.org/opencl-team/python-pyopencl/-/merge_requests/3#note_383761
-        assert np.max(np.abs((np.fmod(a.get(), a2.get()) - b.get()))) < 1e-4
+        assert np.max(np.abs(np.fmod(a.get(), a2.get()) - b.get())) < 1e-4
 
 
 def test_ldexp(ctx_factory):

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -522,7 +522,7 @@ def test_image_3d(ctx_factory):
     shape = (3, 4, 2)
 
     rng = np.random.default_rng(seed=42)
-    a = rng.random(size=shape + (num_channels,), dtype=np.float32)
+    a = rng.random(size=(*shape, num_channels), dtype=np.float32)
 
     queue = cl.CommandQueue(context)
     try:


### PR DESCRIPTION
Was playing around with more rules to see what's in there.

This adds `flake8-logging-format`, `pyupgrade` and the builtin `ruff` rules to the mix. The `RUF` rules were the most annoying to fix, but most of them seemed reasonable. A lot of
```
[1.0] + my_list -> [1.0, *my_list]
```