### PR TITLE
Add example that profiles parallel sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
         -   uses: actions/checkout@v4
         -   name: "Main Script"
             run: |
-                EXTRA_INSTALL="pillow cgen mako imageio"
+                EXTRA_INSTALL="pillow cgen mako imageio matplotlib"
 
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0

--- a/examples/demo_flops.py
+++ b/examples/demo_flops.py
@@ -1,0 +1,66 @@
+import pyopencl as cl
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+src = """
+    __kernel void sum(__global T *x, __global T *y, __global T *z) {
+        const int i = get_global_id(0);
+
+        z[i] = x[i] + y[i];
+    }
+"""
+
+
+# allocates buffers of increasing size, for each run do a parallel sum interpreting
+# the buffer as an array of i8, i16, ...
+# profile the kernels to find the throughput in GFLOPS, useful to estimate the raw computational speed of the hardware
+if __name__ == '__main__':
+    types = [
+        ('i8' , 'char'  , 1),
+        ('i16', 'short' , 2),
+        ('i32', 'int'   , 4),
+        ('i64', 'long'  , 8),
+        # ('f16', 'half'  , 2),
+        ('f32', 'float' , 4),
+        ('f64', 'double', 8)
+    ]
+
+
+    ctx   = cl.create_some_context()
+    queue = cl.CommandQueue(ctx, properties = cl.command_queue_properties.PROFILING_ENABLE)
+
+
+    buffer_size = [2 ** i for i in range(10, 31)]
+    data = np.zeros((len(buffer_size), len(types)))
+
+    for row, nbytes in enumerate(buffer_size):
+        x = cl.Buffer(ctx, cl.mem_flags.READ_ONLY,  nbytes)
+        y = cl.Buffer(ctx, cl.mem_flags.READ_ONLY,  nbytes)
+        z = cl.Buffer(ctx, cl.mem_flags.WRITE_ONLY, nbytes)
+
+        for col, (label, literal, sizeof) in enumerate(types):
+            sums    = nbytes // sizeof
+            header  = f'#define T {literal}\n'
+            kernel  = cl.Program(ctx, header + src).build().sum
+
+            event   = kernel(queue, (sums,), None, x, y, z)
+            event.wait()
+
+            FLOPS = 1e9 * sums / (event.profile.end - event.profile.start)
+            GFLOPS = FLOPS / 1e6
+
+            data[row, col] = GFLOPS
+
+        x.release()
+        y.release()
+        z.release()
+
+    for col, (_, label, _) in enumerate(types):
+        plt.semilogx(buffer_size, data[:, col], label = label)
+
+    plt.title(f'{ctx.devices[0].name}')
+    plt.legend()
+    plt.xlabel('sizeof(vector)')
+    plt.ylabel('GFLOPS')
+    plt.show()


### PR DESCRIPTION
# Description
This program profiles the parallel sum kernel when summing two arrays of increasing size, interpreting the data as char, int, float... the results are plotted with matplotlib, it's an external dependency but it's a common one.

# Rationale
When experimenting with GPU computing is useful to estimate an upper bound on performance, this PR offers an example of how you could use pyopencl events to profile a kernel (I suppose we are profiling only the execution time without the data transfers).
The results show a powerful idea in parallel computing: using shorter types improves throughput

# Possible corners
 * I assumed that the profiling times were in nanoseconds
 * I wanted to work with fp16, but not all devices support it so I commented it out. Maybe we could query at runtime if fp16 arithmetic is supported
