### PR TITLE
Generate nanobind type stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,8 +200,15 @@ if (PYOPENCL_USE_SHIPPED_EXT)
   target_compile_definitions(_cl PRIVATE PYOPENCL_USE_SHIPPED_EXT=1)
 endif()
 
-install(TARGETS _cl LIBRARY DESTINATION pyopencl)
+nanobind_add_stub(
+  pyopencl_stub
+  MODULE pyopencl._cl
+  OUTPUT _cl.pyi
+  PYTHON_PATH $<TARGET_FILE_DIR:_cl>
+  DEPENDS _cl
+)
 
+install(TARGETS _cl LIBRARY DESTINATION pyopencl)
 
 # {{{ Print configuration
 


### PR DESCRIPTION
This is an attempt to make use of [nanobind's stub generation](https://nanobind.readthedocs.io/en/latest/typing.html#stubs)

This does not work at all for now. Problems:

- [ ] How do we convince scikit-build-core to install `py.typed`?
- [ ] `nanobind.stubgen` produces a bunch of lines with `@property` that decorate nothing.
- [ ] Can editable installs work?
- [ ] `nanobind.stubgen` fails during build while trying to import `pytools` (because it's apparently trying to import `pyopencl`)