### PR TITLE
choose_devices: don't short-circuit dev choice when answers available

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1649,6 +1649,7 @@ def choose_devices(interactive: Optional[bool] = None,
     if not devices:
         raise Error("no devices found")
     elif len(devices) == 1 and not answers:
+        print(f"Choosing only available device: {devices[0]}")
         pass
     else:
         if not answers:

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1648,7 +1648,7 @@ def choose_devices(interactive: Optional[bool] = None,
 
     if not devices:
         raise Error("no devices found")
-    elif len(devices) == 1:
+    elif len(devices) == 1 and not answers:
         pass
     else:
         if not answers:
@@ -1672,7 +1672,7 @@ def choose_devices(interactive: Optional[bool] = None,
 
     if answers:
         raise RuntimeError("not all provided choices were used by "
-                "choose_device. (left over: '%s')" % ":".join(answers))
+                "choose_devices. (left over: '%s')" % ":".join(answers))
 
     return devices
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1649,7 +1649,7 @@ def choose_devices(interactive: Optional[bool] = None,
     if not devices:
         raise Error("no devices found")
     elif len(devices) == 1 and not answers:
-        print(f"Choosing only available device: {devices[0]}")
+        cc_print(f"Choosing only available device: {devices[0]}")
         pass
     else:
         if not answers:


### PR DESCRIPTION
Otherwise, spurious errors can occur:

```console
# only single device available on this platform:

$ clinfo -l
Platform #0: AMD Accelerated Parallel Processing
 `-- Device #0: gfx90a:sramecc+:xnack-  
$ PYOPENCL_CTX=AMD:0 python -c "import pyopencl; pyopencl.choose_devices()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/p/lustre1/diener3/Work/enew/pyopencl/pyopencl/__init__.py", line 1674, in choose_devices
    raise RuntimeError("not all provided choices were used by "
pyopencl._cl.RuntimeError: not all provided choices were used by choose_devices. (left over: '0')
```

`PYOPENCL_TEST=AMD:0` works fine in this context.

See also #781.

_Please squash_