### PR TITLE
Context: remove deprecated cache_dir argument from docs

### DIFF
--- a/doc/runtime_platform.rst
+++ b/doc/runtime_platform.rst
@@ -109,7 +109,7 @@ Device
 Context
 -------
 
-.. class:: Context(devices=None, properties=None, dev_type=None, cache_dir=None)
+.. class:: Context(devices=None, properties=None, dev_type=None)
 
     Create a new context. *properties* is a list of key-value
     tuples, where each key must be one of :class:`context_properties`.
@@ -119,17 +119,22 @@ Context
     If neither is specified, a context with a *dev_type* of
     :attr:`device_type.DEFAULT` is created.
 
-    If *cache_dir* is not *None* - it will be used as default *cache_dir*
-    for all its' :class:`Program` instances builds (see also :meth:`Program.build`).
-
     .. note::
 
-        Calling the constructor with no arguments will fail for
+        Calling the constructor with no arguments may fail for
         CL drivers that support the OpenCL ICD (which applies to most modern systems).
         If you want similar, just-give-me-a-context-already behavior, we recommend
-        :func:`create_some_context`. See, e.g. this
+        :func:`create_some_context`.
+
+        See e.g. this
         `explanation by AMD
-        <https://web.archive.org/web/20101114195033/https://developer.amd.com/support/KnowledgeBase/Lists/KnowledgeBase/DispForm.aspx?ID=71>`__.
+        <https://web.archive.org/web/20101114195033/https://developer.amd.com/support/KnowledgeBase/Lists/KnowledgeBase/DispForm.aspx?ID=71>`__:
+
+            **What has changed?**
+
+            In previous beta releases functions such as clGetDeviceIDs() and clCreateContext()
+            accepted a NULL value for the platform parameter. This release no longer
+            allows this - the platform must be a valid one obtained by using the platform API.
 
     .. note::
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -275,7 +275,7 @@ def _find_pyopencl_include_path() -> str:
             # NOTE: only available in Python >=3.9
             from importlib.resources import files
         except ImportError:
-            from importlib_resources import files
+            from importlib_resources import files  # type: ignore[no-redef]
 
         include_path = str(files("pyopencl") / "cl")
         if not exists(include_path):


### PR DESCRIPTION
Followup of #791.

Also expands and clarifies the text regarding no-argument constructors.

cc: #207.