### PR TITLE
set NOMINSIZE, LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ find_package(OpenCL REQUIRED)
 nanobind_add_module(
   _cl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
+  LTO
+  NOMINSIZE
   src/wrap_constants.cpp
   src/wrap_cl.cpp
   src/wrap_cl_part_1.cpp


### PR DESCRIPTION
This results in a ~10% speedup for a simple microbenchmark like:

```python
import pyopencl as cl
import time

ctx = cl.create_some_context()
queue = cl.CommandQueue(ctx)

prg = cl.Program(ctx, """
__kernel void sum()
{

}
""").build()


knl = prg.sum

start = time.time()

for _ in range(100000):
    knl(queue, (1,), None)

# Intentionally disabled, we are only interested in the enqueue time
# queue.finish()

print(time.time() - start)
```