### PR TITLE
MNT: stop using deprecated numpy macros

### DIFF
--- a/src/wrap_cl.hpp
+++ b/src/wrap_cl.hpp
@@ -5893,9 +5893,9 @@ namespace pyopencl
 
     int ary_flags = 0;
     if (order == NPY_FORTRANORDER)
-      ary_flags |= NPY_FARRAY;
+      ary_flags |= NPY_ARRAY_FARRAY;
     else if (order == NPY_CORDER)
-      ary_flags |= NPY_CARRAY;
+      ary_flags |= NPY_ARRAY_CARRAY;
     else
       throw std::runtime_error("unrecognized order specifier");
 

--- a/src/wrap_helpers.hpp
+++ b/src/wrap_helpers.hpp
@@ -142,9 +142,9 @@ namespace py = nanobind;
     \
     int ary_flags = 0; \
     if (order == NPY_FORTRANORDER) \
-      ary_flags |= NPY_FARRAY; \
+      ary_flags |= NPY_ARRAY_FARRAY; \
     else if (order == NPY_CORDER) \
-      ary_flags |= NPY_CARRAY; \
+      ary_flags |= NPY_ARRAY_CARRAY; \
     else \
       throw std::runtime_error("unrecognized order specifier"); \
     \


### PR DESCRIPTION
These were deprecated in np1.7 and will be removed in np2.3 (currently removed on numpy main branch).

xref https://github.com/numpy/numpy/pull/28254/

Without these changes pyopencl fails to compile with numpy main.