### PR TITLE
provide a better error message when no platforms found

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -1597,7 +1597,21 @@ def choose_devices(interactive: bool | None = None,
 
     # {{{ pick a platform
 
-    platforms = get_platforms()
+    try:
+        platforms = get_platforms()
+    except LogicError as e:
+        if "PLATFORM_NOT_FOUND_KHR" in str(e):
+            # With the cl_khr_icd extension, clGetPlatformIDs fails if no platform
+            # is available:
+            # https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetPlatformIDs.html
+            raise RuntimeError("no CL platforms available to ICD loader. "
+                               "Install a CL driver "
+                               "('ICD', such as pocl, rocm, Intel CL) to fix this. "
+                               "See pyopencl docs for help: "
+                               "https://documen.tician.de/pyopencl/"
+                               "misc.html#installation") from e
+        else:
+            raise
 
     if not platforms:
         raise Error("no platforms found")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ name = "pyopencl"
 version = "2025.1"
 description = "Python wrapper for OpenCL"
 readme = "README.rst"
+license = "MIT"
 authors = [
     { name = "Andreas Kloeckner", email = "inform@tiker.net" },
 ]
@@ -24,7 +25,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Other Audience",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: C++",
     "Programming Language :: Python",


### PR DESCRIPTION
before:

```python
>>> import pyopencl as cl
>>> cl.create_some_context()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdiener/Work/e12/pyopencl/pyopencl/__init__.py", line 1708, in create_some_context
    devices = choose_devices(interactive, answers)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdiener/Work/e12/pyopencl/pyopencl/__init__.py", line 1601, in choose_devices
    platforms = get_platforms()
                ^^^^^^^^^^^^^^^
pyopencl._cl.LogicError: clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR
```

after:

```python
>>> cl.create_some_context()
Traceback (most recent call last):
  File "/Users/mdiener/Work/e12/pyopencl/pyopencl/__init__.py", line 1601, in choose_devices
    platforms = get_platforms()
                ^^^^^^^^^^^^^^^
pyopencl._cl.LogicError: clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mdiener/Work/e12/pyopencl/pyopencl/__init__.py", line 1706, in create_some_context
    devices = choose_devices(interactive, answers)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdiener/Work/e12/pyopencl/pyopencl/__init__.py", line 1607, in choose_devices
    raise RuntimeError("no CL platforms available to ICD loader, install a CL driver (such as pocl, rocm, Intel CL)") from e
pyopencl._cl.RuntimeError: no CL platforms available to ICD loader, install a CL driver (such as pocl, rocm, Intel CL)
```