### PR TITLE
CL 1.1 fixes

### DIFF
--- a/src/wrap_cl_part_2.cpp
+++ b/src/wrap_cl_part_2.cpp
@@ -135,9 +135,9 @@ void pyopencl_expose_part_2(py::module_ &m)
           py::arg("context"),
           py::arg("flags"),
           py::arg("format"),
-          py::arg("shape")=py::none(),
-          py::arg("pitches")=py::none(),
-          py::arg("hostbuf")=py::none()
+          py::arg("shape").none(true)=py::none(),
+          py::arg("pitches").none(true)=py::none(),
+          py::arg("hostbuf").none(true)=py::none()
           )
 #if PYOPENCL_CL_VERSION >= 0x1020
       .def_static(
@@ -161,7 +161,7 @@ void pyopencl_expose_part_2(py::module_ &m)
           py::arg("flags"),
           py::arg("format"),
           py::arg("desc"),
-          py::arg("hostbuf")=py::none()
+          py::arg("hostbuf").none(true)=py::none()
           )
 #endif
       .DEF_SIMPLE_METHOD(get_image_info)

--- a/test/test_algorithm.py
+++ b/test/test_algorithm.py
@@ -1136,6 +1136,9 @@ def test_bitonic_argsort(ctx_factory: cl.CtxFactory, size, dtype):
     if (dev.platform.name == "Portable Computing Language"
             and sys.platform == "darwin"):
         pytest.xfail("Bitonic sort crashes on Apple PoCL")
+    if (dev.platform.name == "Portable Computing Language"
+            and cl.get_cl_header_version() < (1, 2)):
+        pytest.xfail("does not work on pocl with CL pre 1.2")
     if (dev.platform.name == "Apple" and dev.type & cl.device_type.CPU):
         pytest.xfail("Bitonic sort won't work on Apple CPU: no workgroup "
             "parallelism")

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -235,6 +235,9 @@ def test_zeros_large_array(ctx_factory: cl.CtxFactory):
             and platform.system() == "Windows":
         pytest.xfail("large array fail with out-of-host memory with"
                 "Intel CPU runtime as of 2022-10-05")
+    if (dev.platform.name == "Portable Computing Language"
+            and cl.get_cl_header_version() < (1, 2)):
+        pytest.xfail("does not work on pocl with CL pre 1.2")
 
     size = 2**28 + 1
     if dev.address_bits == 64 and dev.max_mem_alloc_size >= 8 * size:
@@ -1782,6 +1785,9 @@ def test_zero_size_array(ctx_factory: cl.CtxFactory, empty_shape):
 
     if queue.device.platform.name == "Intel(R) OpenCL":
         pytest.xfail("size-0 arrays fail on Intel CL")
+    if (queue.device.platform.name == "Portable Computing Language"
+            and cl.get_cl_header_version() < (1, 2)):
+        pytest.xfail("does not work on pocl with CL pre 1.2")
 
     a = cl_array.zeros(queue, empty_shape, dtype=np.float32)
     b = cl_array.zeros(queue, empty_shape, dtype=np.float32)


### PR DESCRIPTION
These were broken by either #546 or #833 and caused ongoing failures in the Gitlab CI, like this: https://gitlab.tiker.net/inducer/pyopencl/-/jobs/851417.