### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,9 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+      groups:
+          actions:
+              patterns:
+                  - "*"
 
 # vim: sw=4


### PR DESCRIPTION
This groups dependabot updates into a single pull request, if possible, to avoid it being a bit spammy: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--.