### PR TITLE
Build Linux aarch64 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-14]
+        include:
+        - os: ubuntu-latest
+          cibw_archs_linux: x86_64
+        - os: ubuntu-24.04-arm
+          cibw_archs_linux: aarch64
+        - os: windows-latest
+        - os: macos-15-intel
+        - os: macos-14
 
     steps:
       - uses: actions/checkout@v6
@@ -35,6 +42,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.0
         env:
+            CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
             CIBW_ENVIRONMENT_WINDOWS: >
                 CL_INC_DIR='${{github.workspace}}/OpenCL-Headers/install/include'
                 CL_LIB_DIR="C:/Program Files/OpenCL-ICD-Loader/lib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ extend-ignore = [
     "C90",  # McCabe complexity
     "UP031", # use f-strings instead of %
     "UP032", # use f-strings instead of .format
+
+    # FIXME: This is a longer discussion...
+    "RUF067", # __init__ should only contain reexports
 ]
 exclude = [
     "examples/gl_interop_demo.py",


### PR DESCRIPTION
GitHub Actions [now offers](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) native arm64 runners. See all the runners currently offered [here](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

Verification:
* passed CI build [here](https://github.com/adeebshihadeh/pyopencl/actions/runs/20703593264/job/59429797260)
* installed the wheel from the above run in [openpilot CI](https://github.com/commaai/openpilot/pull/36984) (where we had been building the wheel ourselves previously), as an e2e sanity check